### PR TITLE
Feature/updates workflow upload form

### DIFF
--- a/src/app/components/workflow-uploader/workflow-uploader.component.html
+++ b/src/app/components/workflow-uploader/workflow-uploader.component.html
@@ -166,18 +166,39 @@
                 <div id="workflow-part" class="content px-5" role="tabpanel" aria-labelledby="workflow-part-trigger">
                   <!-- workflow UUID -->
                   <div *ngIf="source !== 'registry'" class="form-group mt-4">
-                    <label for="workflow-uuid" class="m-0">UUID (<i
-                        class="fas fa-star-of-life fa-xs text-muted"></i>)</label>
-                    <div class="text-muted font-weight-light">
-                      Enter a UUID for the workflow
+                    <div *ngIf="!isEditingUUID">
+                      <label for="workflow-uuid" class="m-0">UUID</label>
+                      <div class="text-muted font-weight-light small">
+                        The following identifier will be assigned to the workflow
+                        <div class="float-right">
+                          <a class="btn btn-sm m-2" (click)="enableEditingUUID()" title="Click to change the identifier">
+                            <i class="far fa-edit"></i> edit
+                          </a>
+                        </div>
+                      </div>
+                      <div class='mr-4 text-muted'>
+                        <div class='badge badge-primary mr-1 d-inline'>LifeMonitor ID</div>
+                        <div class="d-inline mt-3" style="font-size: large; font-weight: 100;">
+                          {{ workflowUUID }}
+                        </div>
+                      </div>
+
                     </div>
-                    <input type="text" name="wf-uuid" [ngClass]="
-                        !errors['uuid']
-                          ? 'form-control'
-                          : 'form-control is-invalid'
-                      " id="workflow-uuid" [(ngModel)]="workflowUUID" placeholder="Enter workflow UUID"
-                      aria-describedby="workflow-uuid-error" aria-invalid="true" />
-                    <span id="workflow-uuid-error" class="error invalid-feedback">{{ errors['uuid'] }}</span>
+                    <div *ngIf="isEditingUUID">
+                      <label for="workflow-uuid" class="m-0">UUID (<i
+                        class="fas fa-star-of-life fa-xs text-muted"></i>)
+                      </label>
+                      <div class="text-muted font-weight-light">
+                        Enter a UUID for the workflow
+                      </div>
+                      <input type="text" name="wf-uuid" [ngClass]="
+                          !errors['uuid']
+                            ? 'form-control'
+                            : 'form-control is-invalid'
+                        " id="workflow-uuid" [(ngModel)]="workflowUUID" placeholder="Enter workflow UUID"
+                        aria-describedby="workflow-uuid-error" aria-invalid="true" />
+                      <span id="workflow-uuid-error" class="error invalid-feedback">{{ errors['uuid'] }}</span>
+                    </div>
                   </div>
 
                   <div *ngIf="source === 'registry' && selectedRegistry" class="form-group mt-4">

--- a/src/app/components/workflow-uploader/workflow-uploader.component.html
+++ b/src/app/components/workflow-uploader/workflow-uploader.component.html
@@ -89,7 +89,14 @@
                       </div>
 
                       <!-- RO-Crate authorization header -->
-                      <div class="form-group mt-4">
+                      <div class="float-right">
+                        <a class="text-primary collapsed" data-toggle="collapse" href="#authForm"
+                           role="button" aria-expanded="false" aria-controls="Advanced Setting">
+                          Advanced Settings
+                        </a>
+                      </div>
+
+                      <div id="authForm" class="collapse form-group mt-4">
                         <label for="workflow-auth" class="m-0">Authorization Header</label>
                         <div class="text-muted font-weight-light">
                           Enter the optional authorization header if required to

--- a/src/app/components/workflow-uploader/workflow-uploader.component.scss
+++ b/src/app/components/workflow-uploader/workflow-uploader.component.scss
@@ -1,3 +1,19 @@
 .active .bs-stepper-circle {
   background-color: var(--primary);
 }
+
+[data-toggle='collapse']:after {
+  display: inline-block;
+  font-family: "Font Awesome 5 Free";
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: '\f0d7';
+  transform: rotate(0deg);
+  transition: all linear 0.25s;
+}
+
+[data-toggle='collapse'].collapsed:after {
+  transform: rotate(90deg);
+}

--- a/src/app/components/workflow-uploader/workflow-uploader.component.ts
+++ b/src/app/components/workflow-uploader/workflow-uploader.component.ts
@@ -56,6 +56,7 @@ export class WorkflowUploaderComponent
 
   _registries: Registry[];
 
+  private _editUUID: boolean = false;
   private _registryWorkflows: RegistryWorkflow[] = [];
   private _selectedRegistry: Registry = null;
   private _selectedRegistryWorkflow: RegistryWorkflow = null;
@@ -158,6 +159,14 @@ export class WorkflowUploaderComponent
     let valid = this.checkIfValidUUID(value);
     console.log('Setting workflow UUID: ' + value + ' (valid: ' + valid + ')');
     this._setError('uuid', valid ? null : 'Not valid UUID');
+  }
+
+  public enableEditingUUID(){
+    this._editUUID = true;
+  }
+
+  public get isEditingUUID(): boolean {
+    return this._editUUID;
   }
 
   public get workflowName(): string {
@@ -487,6 +496,7 @@ export class WorkflowUploaderComponent
     this.workflowUUID = uuidv4();
     this.workflowVersion = '1.0';
     this.roCrateFile = null;
+    this._editUUID = false;
     this._workflowROCrate = null;
     this.roCrateURL = new UrlValue(this.httpClient);
     this._registrationError = null;


### PR DESCRIPTION
This PR extends #13  by introducing the following minor updates:
* the workflow UUID is fixed and automatically generated by the system but users can optionally change it
<img width="681" alt="Screenshot 2021-12-16 at 12 34 02" src="https://user-images.githubusercontent.com/1832243/146364438-6924d1e3-7662-4012-a648-4f3628344057.png">

* the input field for the authorisation header is hidden by default within a collapsible "Advanced Settings" pane
<img width="701" alt="Screenshot 2021-12-16 at 12 46 32" src="https://user-images.githubusercontent.com/1832243/146366138-1d9418ea-a4cd-4030-9e0c-7f4a9686dd6f.png">
