### PR TITLE
Feature/notifications

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { AppButtonComponent } from './components/app-button/app-button.component';
+import { InputDialogComponent } from './components/input-dialog/input-dialog.component';
 import { LoaderComponent } from './components/loader/loader.component';
 import { RocrateLogoComponent } from './components/rocrate-logo/rocrate-logo.component';
 import { SearchBarComponent } from './components/search-bar/search-bar.component';
@@ -19,6 +20,7 @@ import { StatsPieChartComponent } from './components/stats-pie-chart/stats-pie-c
 import { TestInstancesComponent } from './components/test-instances/test-instances.component';
 import { TestSuitesComponent } from './components/test-suites/test-suites.component';
 import { WorkflowHeaderComponent } from './components/workflow-header/workflow-header.component';
+import { WorkflowUploaderComponent } from './components/workflow-uploader/workflow-uploader.component';
 import { HomeComponent } from './pages/home/home.component';
 import { LoginComponent } from './pages/login/login.component';
 import { FooterComponent } from './pages/main/footer/footer.component';
@@ -31,6 +33,7 @@ import { MenuSidebarComponent } from './pages/main/menu-sidebar/menu-sidebar.com
 import { RegisterComponent } from './pages/register/register.component';
 import { ItemFilterPipe } from './utils/filters/item-filter.pipe';
 import { SortingFilterPipe } from './utils/filters/sorting-filter.pipe';
+import { SortingNotificationFilterPipe } from './utils/filters/sorting-notification-filter.pipe';
 import { StatsFilterPipe } from './utils/filters/stats-filter.pipe';
 import { HttpErrorInterceptor } from './utils/interceptors/http-error.interceptor';
 import { AppConfigService } from './utils/services/config.service';
@@ -38,8 +41,7 @@ import { BlankComponent } from './views/blank/blank.component';
 import { DashboardComponent } from './views/dashboard/dashboard.component';
 import { SuiteComponent } from './views/suite/suite.component';
 import { WorkflowComponent } from './views/workflow/workflow.component';
-import { InputDialogComponent } from './components/input-dialog/input-dialog.component';
-import { WorkflowUploaderComponent } from './components/workflow-uploader/workflow-uploader.component';
+
 
 
 registerLocaleData(localeEn, 'en-EN');
@@ -74,6 +76,7 @@ export function initConfigService(appConfig: AppConfigService) {
     TestInstancesComponent,
     StatsFilterPipe,
     ItemFilterPipe,
+    SortingNotificationFilterPipe,
     SortingFilterPipe,
     SearchBarComponent,
     LoaderComponent,

--- a/src/app/models/notification.model.ts
+++ b/src/app/models/notification.model.ts
@@ -1,0 +1,38 @@
+import { Model } from './base.models';
+import { Suite } from './suite.models';
+
+export class UserNotification extends Model {
+  id: string;
+  data: object;
+  created: number;
+  read: number;
+  uuid: string;
+  title: string;
+  body: string;
+  icon: string;
+  lang: string;
+  tag: string;
+  event: string;
+
+  constructor(rawData?: Object, skip?: []) {
+    super(rawData, skip);
+    this.updateIcon();
+  }
+
+  private updateIcon() {
+    if (this.event === 'BUILD_FAILED') {
+      this.icon = "fa-minus-circle fas";
+    } else {
+      this.icon = "fas fa-info-circle";
+    }
+  }
+
+  public asUrlParam(): string {
+    if (this.event === "BUILD_FAILED") {
+      return Suite.getUrlParam(
+        this.data["build"]["workflow"]["uuid"],
+        this.data["build"]["suite"]["uuid"]);
+    }
+    return null;
+  }
+}

--- a/src/app/models/stats.model.ts
+++ b/src/app/models/stats.model.ts
@@ -34,6 +34,7 @@ export interface StatsItem {
   latestBuilds: any;
   class: string;
   statusIcon: string;
+  subscriptions: Array<object>;
 
   getStatus(): string;
 }
@@ -43,6 +44,7 @@ export class AggregatedStatusStatsItem extends Model implements StatsItem {
   name: string;
   status: any;
   latestBuilds: any;
+  subscriptions: Array<object>;
 
   private static colorMapping: object = {
     all_passing: 'var(--test-passed)',
@@ -193,6 +195,7 @@ export class StatusStatsItem extends Model implements StatsItem {
   latestBuilds: TestBuild[];
   timestamp: number;
   duration: number;
+  subscriptions: Array<object>;
 
   constructor(_rawData: Object) {
     super(_rawData);

--- a/src/app/models/suite.models.ts
+++ b/src/app/models/suite.models.ts
@@ -20,10 +20,14 @@ export class Suite extends AggregatedStatusStatsItem {
   }
 
   public asUrlParam() {
+    return Suite.getUrlParam(this.workflow.uuid, this.uuid);
+  }
+
+  public static getUrlParam(workflow_uuid: string, suite_uuid: string): string {
     return btoa(
       JSON.stringify({
-        workflow: this.workflow.uuid,
-        suite: this.uuid,
+        workflow: workflow_uuid,
+        suite: suite_uuid,
       })
     );
   }

--- a/src/app/models/workflow.model.ts
+++ b/src/app/models/workflow.model.ts
@@ -11,7 +11,6 @@ export class Workflow extends AggregatedStatusStatsItem {
   registry: Object;
   version: Object;
   status: Status;
-  subscriptions: Array<object>;
   type: string = 'galaxy'; // FIXME
   _suites: AggregatedStatusStats;
   private _latestBuilds: TestBuild[];

--- a/src/app/pages/main/header/notifications-dropdown-menu/notifications-dropdown-menu.component.html
+++ b/src/app/pages/main/header/notifications-dropdown-menu/notifications-dropdown-menu.component.html
@@ -1,34 +1,78 @@
-<li class="nav-item dropdown">
-  <a class="nav-link" data-html="true" data-toggle="dropdown" (click)="toggleDropdownMenu()">
+<li class="nav-item dropdown" *ngIf="notifications && notifications.length > 0">
+  <a
+    class="nav-link"
+    data-html="true"
+    data-toggle="dropdown"
+    (click)="toggleDropdownMenu()"
+  >
     <i class="far fa-bell"></i>
-    <span class="badge badge-warning navbar-badge">0</span>
+    <span
+      *ngIf="notificationsToRead.length > 0"
+      class="badge badge-warning navbar-badge text-bold"
+    >
+      {{ notificationsToRead.length }}
+    </span>
   </a>
   <div #dropdownMenu class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
-    <span class="dropdown-item dropdown-header">0 Notifications</span>
-    <div class="dropdown-divider"></div>
-    <!-- <a href="#" class="dropdown-item">
-      <i class="fas fa-envelope mr-2"></i> 4 new messages
-      <span class="float-right text-muted text-sm">3 mins</span>
-    </a>
-    <div class="dropdown-divider"></div>
-    <a href="#" class="dropdown-item">
-      <i class="fas fa-users mr-2"></i> 8 friend requests
-      <span class="float-right text-muted text-sm">12 hours</span>
-    </a>
-    <div class="dropdown-divider"></div>
+    <div style="max-height: 200px; overflow-y: scroll">
+      <ng-container *ngFor="let nd of notificationDates">
+        <div class="text-center text-muted mt-2" style="font-size: 9pt">
+          <span class="text-bold">{{ nd | date: 'fullDate' }}</span>
+        </div>
+        <div class="dropdown-divider"></div>
+        <ng-container
+          *ngFor="
+            let n of getNotificationOfDay(nd)
+              | sortingNotificationFilter: 'desc';
+            index as i;
+            first as isFirst
+          "
+          class="w-100"
+        >
+          <a
+            [routerLink]="['/suite', { s: n.asUrlParam() }]"
+            class="dropdown-item {{ n.read ? 'text-muted' : '' }}"
+            style="{{ n.read ? 'opacity: 60%;' : '' }}"
+            (click)="setNotificationAsRead(n)"
+          >
+            <div
+              *ngIf="n.event === 'BUILD_FAILED'"
+              class="w-100 mt-2 {{ n.read ? 'text-muted' : 'text-red' }}"
+            >
+              <i class="{{ n.icon }} mr-1"></i>
+              Build
+              <span class="text-bold">{{ n.data.build.build_id }}</span> of
+              instance
+              <span class="text-bold">{{ n.data.build.instance.name }}</span>
+              failed
+            </div>
+            <div class="text-small mx-4" style="font-size: 9pt">
+              <div>
+                <span class="text-bold mt-n2">workflow: </span>
+                {{ n.data.build.workflow.name }}
+              </div>
+              <div>
+                <span class="text-bold mt-n2">suite: </span>
+                {{ n.data.build.suite.name }}
+              </div>
+            </div>
+          </a>
+        </ng-container>
+      </ng-container>
+    </div>
+    <!--<div class="dropdown-divider"></div>
     <a href="#" class="dropdown-item">
       <i class="fas fa-file mr-2"></i> 3 new reports
       <span class="float-right text-muted text-sm">2 days</span>
+    </a>-->
+    <!--<div class="dropdown-divider"></div>
+    <a href="#" class="dropdown-item dropdown-footer">
+      Mark as read all {{ !notifications ? 0 : notifications.length }} notifications
+    </a>-->
+    <div class="dropdown-divider"></div>
+    <a class="dropdown-item dropdown-footer" (click)="deleteAllNotifications()">
+      <i class="fas fa-trash-alt mr-1"></i>
+      Clear all notifications ({{ !notifications ? 0 : notifications.length }})
     </a>
-    <div class="dropdown-divider"></div> -->
-    <a href="#" class="dropdown-item dropdown-footer">See All Notifications</a>
   </div>
 </li>
-
-<ng-template #notification>
-  <a href="#" class="dropdown-item">
-    <i class="fas fa-envelope mr-2"></i> 4 new messages
-    <span class="float-right text-muted text-sm">3 mins</span>
-  </a>
-  <div class="dropdown-divider"></div>
-</ng-template>

--- a/src/app/pages/main/header/notifications-dropdown-menu/notifications-dropdown-menu.component.scss
+++ b/src/app/pages/main/header/notifications-dropdown-menu/notifications-dropdown-menu.component.scss
@@ -3,3 +3,7 @@
     cursor: pointer;
   }
 }
+
+a.text-muted:hover {
+  color: #6c757d !important;
+}

--- a/src/app/pages/main/header/notifications-dropdown-menu/notifications-dropdown-menu.component.ts
+++ b/src/app/pages/main/header/notifications-dropdown-menu/notifications-dropdown-menu.component.ts
@@ -1,11 +1,10 @@
+import { formatDate } from '@angular/common';
 import {
-  Component,
-  OnInit,
-  ViewChild,
-  HostListener,
-  ElementRef,
-  Renderer2,
+  Component, ElementRef, HostListener, OnInit, Renderer2, ViewChild
 } from '@angular/core';
+import { Router } from '@angular/router';
+import { UserNotification } from 'src/app/models/notification.model';
+import { AppService } from 'src/app/utils/services/app.service';
 
 @Component({
   selector: 'app-notifications-dropdown-menu',
@@ -22,23 +21,102 @@ export class NotificationsDropdownMenuComponent implements OnInit {
     }
   }
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer2) {}
 
-  ngOnInit() {}
+  public notifications: UserNotification[];
+  private notificationsByDate: {};
+
+  constructor(
+    private router: Router,
+    private elementRef: ElementRef,
+    private renderer: Renderer2,
+    private appService: AppService) { }
+
+  ngOnInit() {
+    this.appService.loadNotifications().subscribe((data: UserNotification[]) => {
+      console.log("loaded notifications...", data);
+      this.updateNotifications(data);
+    })
+  }
+
+  private updateNotifications(notifications: UserNotification[]) {
+    console.log("Updating notifications...", notifications);
+    this.notifications = notifications;
+    this.notificationsByDate = this.groupNotificationsByDate(notifications);
+    console.log("Notifications by date: ", this.notifications);
+  }
+
+  public get notificationsToRead(): UserNotification[] {
+    if (!this.notifications) return [];
+    return this.notifications.filter((n: UserNotification) => !n.read);
+  }
+
+  public get notificationDates() {
+    return Object.keys(this.notificationsByDate);
+  }
+
+  public getNotificationOfDay(day: string) {
+    return day in this.notificationsByDate ? this.notificationsByDate[day] : [];
+  }
+
+  private groupNotificationsByDate(notifications: UserNotification[]) {
+    let result = {};
+    for (let n of notifications) {
+      let date = formatDate(n.created, 'yyyy-MM-dd', 'en-US');
+      if (!(date in result)) {
+        result[date] = [];
+      }
+      result[date].push(n);
+    }
+    return result;
+  }
+
+  public setNotificationAsRead(n: UserNotification) {
+    this.appService.setNotificationsReadingTime([n]).subscribe((data) => {
+      console.log("Notification marked as read", n);
+      this.hideDropdownMenu();
+    });
+  }
+
+
+  public markAllAsRead(notifications: UserNotification[] = null) {
+    this.appService.setNotificationsReadingTime(notifications ? notifications : this.notifications)
+      .subscribe((data) => {
+        console.log("Notifiations marked as read", notifications);
+        this.hideDropdownMenu();
+      });
+  }
+
+  public deleteAllNotifications() {
+    this.appService.deleteNotifications(this.notifications)
+      .subscribe(() => {
+        console.log("All notifications deleted", this.notifications);
+        this.updateNotifications([]);
+        this.hideDropdownMenu();
+      });
+  }
+
+
+  public navigateTo(url: string, params: object) {
+    return this.router.navigate([url, params]);
+  }
 
   toggleDropdownMenu() {
-    if (this.dropdownMenu.nativeElement.classList.contains('show')) {
-      this.hideDropdownMenu();
-    } else {
-      this.showDropdownMenu();
+    if (this.dropdownMenu) {
+      if (this.dropdownMenu.nativeElement.classList.contains('show')) {
+        this.hideDropdownMenu();
+      } else {
+        this.showDropdownMenu();
+      }
     }
   }
 
   showDropdownMenu() {
-    this.renderer.addClass(this.dropdownMenu.nativeElement, 'show');
+    if (this.dropdownMenu)
+      this.renderer.addClass(this.dropdownMenu.nativeElement, 'show');
   }
 
   hideDropdownMenu() {
-    this.renderer.removeClass(this.dropdownMenu.nativeElement, 'show');
+    if (this.dropdownMenu)
+      this.renderer.removeClass(this.dropdownMenu.nativeElement, 'show');
   }
 }

--- a/src/app/utils/filters/sorting-notification-filter.pipe.ts
+++ b/src/app/utils/filters/sorting-notification-filter.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { UserNotification } from 'src/app/models/notification.model';
+
+@Pipe({
+  name: 'sortingNotificationFilter',
+})
+export class SortingNotificationFilterPipe implements PipeTransform {
+  transform(value: UserNotification[], order: string = 'asc'): UserNotification[] {
+    console.log('Sorting Input: ', order);
+    return value.sort(
+      (a, b) =>
+      (
+        (a.created >= b.created || !a.read && b.read ? 1 : -1)
+        * (order === 'asc' ? 1 : -1)
+      )
+    );
+  }
+}

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -211,16 +211,16 @@
                   </div>
                   <div *ngIf="isUserLogged()">
                     <span *ngIf="w.subscriptions !== undefined">
-                      <a *ngIf="searchModeEnabled && !isEditable(w) && (!w.subscriptions || w.subscriptions.length == 0)"
+                      <a *ngIf="(searchModeEnabled || editModeEnabled) && (!w.subscriptions || w.subscriptions.length == 0)"
                         class="badge badge-success mt-3 ml-n1 mr-2" (click)="subscribeWorkflow(w)">
                         SUBSCRIBE
                       </a>
                       <div
-                        *ngIf="!editModeEnabled && searchModeEnabled && (isEditable(w) || w.subscriptions && w.subscriptions.length > 0)"
-                        class="badge badge-primary mt-3 ml-n1 mr-2" (click)="subscribeWorkflow(w)">
+                        *ngIf="!editModeEnabled && searchModeEnabled && (w.subscriptions && w.subscriptions.length > 0)"
+                        class="badge badge-primary mt-3 ml-n1 mr-2" (click)="unsubscribeWorkflow(w)">
                         SUBSCRIBED
                       </div>
-                      <a *ngIf="editModeEnabled && !isEditable(w) && w.subscriptions && w.subscriptions.length > 0"
+                      <a *ngIf="editModeEnabled && w.subscriptions && w.subscriptions.length > 0"
                         class="badge badge-danger mt-3 ml-n1 mr-2" (click)="unsubscribeWorkflow(w)">
                         UNSUBSCRIBE
                       </a>

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -52,7 +52,7 @@ export class DashboardComponent implements OnInit, OnChanges {
           this._workflowNameFilter
         );
         this.destroyDataTable();
-        this.filteredWorkflows = this._workflowStats.all;
+        this.filteredWorkflows = this.searchModeEnabled ? this._workflowStats.all : this._workflowStats.all.filter((v) => v.subscriptions && v.subscriptions.length > 0);
         console.log('Stats', data);
         this.cdref.detectChanges();
         this.initDataTable();
@@ -154,11 +154,12 @@ export class DashboardComponent implements OnInit, OnChanges {
     console.log('Unsubscribing from workflow: ', w);
     this.appService.unsubscribeWorkflow(w).subscribe((w) => {
       console.log('Workflow subscription deleted!');
-      this.appService.loadWorkflows(
-        !this.isUserLogged(),
-        this.isUserLogged(),
-        this.isUserLogged()
-      );
+      this.destroyDataTable();
+      this.filteredWorkflows = this.searchModeEnabled
+        ? this._workflowStats.all
+        : this._workflowStats.all.filter(
+          (v) => v.subscriptions && v.subscriptions.length > 0
+        );
     });
   }
 


### PR DESCRIPTION
This PR introduces the support for user notifications.

* Notifications are accessible through the bell on top right side of the menu bar. 
* The yellow badge shows the number of new notifications. 

<img width="737" alt="Screenshot 2022-01-28 at 14 48 09" src="https://user-images.githubusercontent.com/1832243/151557926-5ffd84fa-cd97-4c07-8c92-4f537c11a692.png">

* Notifications are grouped by day.

* Only notifications for the `BUILD_FAILED` event are supported at the moment.
* When users click on such a notification, the proper failing the instance will be displayed. Also, the notification will be marked as read and displayed in grey.
* Users can delete their notifications by clicking _"Clear all notifications"_ on the bottom of the dropdown menu

<img align="left" style="margin: 0 auto" width="377" alt="Screenshot 2022-01-27 at 17 38 27" src="https://user-images.githubusercontent.com/1832243/151555609-9f170939-785f-4296-b84a-c37cd38b898e.png">

<img align="right" width="379" alt="Screenshot 2022-01-28 at 14 43 41" src="https://user-images.githubusercontent.com/1832243/151558887-2555742f-9b29-4854-b6b8-8401ea947f19.png">

