### PR TITLE
build/fix deprecation warnings on CI pipeline

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2
 
       # DockerHub Login
       - name: Login to DockerHub

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,7 +51,7 @@ jobs:
             org.opencontainers.image.version=${{ env.SOFTWARE_VERSION }}.build${{ github.run_number }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,7 +31,6 @@ jobs:
         run: |
           sw_version=$(jq -r ".version" package.json)
           echo "SOFTWARE_VERSION=${sw_version}" >> $GITHUB_ENV
-          echo ::set-output name=sw_version::${sw_version}
 
       # Extract Docker metadata
       - name: Extract Docker metadata

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
         # Set Docker image
       - name: Set up Docker repository
@@ -36,7 +36,7 @@ jobs:
       # Extract Docker metadata
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.DOCKERHUB_REPO }}
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       # DockerHub Login
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: ${{ env.ENABLE_DOCKER_PUSH == 'true' }}
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
@@ -69,7 +69,7 @@ jobs:
 
       # Build and push
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .


### PR DESCRIPTION
* update outdated GitHub Actions on CI pipeline
* remove deprecated `set-output` command