### PR TITLE
feat/browse button + minor UI fixes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,6 +18,9 @@ export class AppComponent {
       .on('mouseout', '[data-toggle="tooltip"]', function () {
         $(this).tooltip('hide');
       })
+      .on('keyup', '[data-toggle="tooltip"]', function () {
+        $(this).tooltip('hide');
+      })
       .on('click', '[data-toggle="tooltip"]', function () {
         $(this).tooltip('hide');
       });

--- a/src/app/components/loader/loader.component.html
+++ b/src/app/components/loader/loader.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="enabled" class="row">
-  <div id="loader">
+  <div id="loader" [ngStyle]="{ 'margin-top': marginTop + 'px' }">
     <div class="dot"></div>
     <div class="dot"></div>
     <div class="dot"></div>

--- a/src/app/components/loader/loader.component.ts
+++ b/src/app/components/loader/loader.component.ts
@@ -7,6 +7,7 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class LoaderComponent implements OnInit {
   @Input() enabled: boolean = true;
+  @Input() marginTop: string = "auto";
 
   constructor() {}
 

--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -1,21 +1,42 @@
-<div class="input-group p-5">
+<div [ngClass]="showAllButtonName ? 'input-group p-5 ml-5' : 'input-group p-5'">
   <div class="input-group-prepend">
-    <span class="input-group-text"><i class="fas fa-search"></i></span>
+    <span class="input-group-text"><i class="fas fa-angle-right"></i></span>
   </div>
-  <input #searchInputText (keyup.enter)="onKeyUpEnter()"
-    type="text" [(ngModel)]="actualFilterValue" class="form-control font-weight-light"
-    placeholder="Search for {{elementType}}" aria-label="search" aria-describedby="basic-addon1" 
-    data-toggle="tooltip" data-placement="bottom" data-html="true"
-    title="Press ENTER to list all {{elementType}} or search {{elementType}} by UUID or Name"/>
+  <input
+    #searchInputText
+    (keyup.enter)="onKeyUpEnter()"
+    type="text"
+    [(ngModel)]="actualFilterValue"
+    class="form-control font-weight-light border-right-0"
+    stule="border-color: gray"
+    placeholder="Search for {{ elementType }}"
+    aria-label="search"
+    aria-describedby="basic-addon1"
+    data-toggle="tooltip"
+    data-placement="bottom"
+    data-html="true"    
+    title="Press ENTER to list all {{ elementType }} or search {{
+      elementType
+    }} by UUID or Name"
+  />
 
   <div class="input-group-append">
-    <button *ngIf="actualFilterValue || searchAll" class="btn btn-outline-secondary border-right-0" type="button" (click)="reset()"
-      aria-haspopup="true" aria-expanded="false"
-      data-toggle="tooltip" data-placement="top" data-html="true"
-      title="Clear search for {{elementType}}">
+    <button
+      *ngIf="actualFilterValue"
+      class="btn btn-outline-secondary border-left-0 border-right-0 border-left-0 bg-white"
+      style="border-color: #ced4da"
+      type="button"
+      (click)="reset()"
+      aria-haspopup="true"
+      aria-expanded="false"
+      data-toggle="tooltip"
+      data-placement="top"
+      data-html="true"
+      title="Clear search for {{ elementType }}"
+    >
       <i class="fas fa-window-close"></i>
     </button>
-    <button class="btn btn-outline-secondary border-left-0" type="button" (click)="changeSortingOrder()"
+    <!-- <button class="btn btn-outline-secondary border-left-0" type="button" (click)="changeSortingOrder()"
       aria-haspopup="true" aria-expanded="false">
       <i *ngIf="actualSortingOrder == 'asc'" class="fas fa-sort-amount-up"
          data-toggle="tooltip" data-placement="top" data-html="true"
@@ -23,7 +44,7 @@
       <i *ngIf="actualSortingOrder == 'desc'" class="fas fa-sort-amount-down"
          data-toggle="tooltip" data-placement="top" data-html="true"
          title="Sort {{elementType}} in descending order"></i>
-    </button>
+    </button> -->
     <!-- <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown"
       aria-haspopup="true" aria-expanded="false">
       <i class="fas fa-sort-amount-up"></i> Filter

--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="showAllButtonName ? 'input-group p-5 ml-5' : 'input-group p-5'">
+<div [ngClass]="enableBrowseButton ? 'input-group p-5 ml-5' : 'input-group p-5'">
   <div class="input-group-prepend">
     <span class="input-group-text"><i class="fas fa-angle-right"></i></span>
   </div>
@@ -14,10 +14,8 @@
     aria-describedby="basic-addon1"
     data-toggle="tooltip"
     data-placement="bottom"
-    data-html="true"    
-    title="Press ENTER to list all {{ elementType }} or search {{
-      elementType
-    }} by UUID or Name"
+    data-html="true"
+    [title]="'search ' + elementType + ' by UUID or Name'"
   />
 
   <div class="input-group-append">
@@ -57,36 +55,63 @@
     </div> -->
   </div>
   <button
-    *ngIf="browseButton"
+    #searchButton
+    [disabled]="!allowEmptySearch && !actualFilterValue"
     class="btn btn-primary"
     data-toggle="tooltip"
     data-placement="bottom"
     data-html="true"
-    title="list all {{ elementType }} or search {{
-      elementType
-    }} by UUID or Name"
+    [title]="
+      actualFilterValue
+        ? 'search ' + elementType + ' by UUID or name'
+        : 'browse registered ' + elementType
+    "
+    [title]="'search ' + elementType + ' by UUID or name'"
     (click)="onKeyUpEnter()"
-    style="width: 105px"
   >
     <i class="fas fa-search mx-2"></i>
-    <span>Search</span>
+    <span>{{ actualFilterValue ? 'Search' : searchButtonName }}</span>
   </button>
 
-  <div *ngIf="showAllButtonName" class="mx-2 mr-4" style="width: 135px">
+  <div *ngIf="enableBrowseButton" class="mx-2 mr-4">
     <button
-      [hidden]="!actualFilterValue && !searchAll"
+      #browseButton
+      type="button"
+      class="btn btn-primary"
+      [ngClass]="{
+        'browse-disabled': !browseButtonEnabled,
+        'browse-enabled': browseButtonEnabled
+      }"
+      [hidden]="!enableBrowseButton"
+      style="min-width: 132px"
       class="btn btn-primary"
       type="button"
-      (click)="reset()"
-      aria-haspopup="true"
-      aria-expanded="false"
-      data-toggle="tooltip"
-      data-placement="top"
-      data-html="true"
-      title="Show {{ showAllButtonName }}"
+      (click)="onBrowseButtonClick($event)"
     >
-      <i class="fas fa-list mx-2"></i>
-      <span>{{ showAllButtonName }}</span>
+      <div
+        *ngIf="browseButtonEnabled"
+        aria-haspopup="true"
+        aria-expanded="false"
+        data-toggle="tooltip"
+        data-placement="top"
+        data-html="true"
+        title="Go back to the {{ goBackButtonName }}"
+      >
+        <i class="fas fa-list mx-2"></i>
+        <span>{{goBackButtonName}}</span>
+      </div>
+      <div
+        *ngIf="!browseButtonEnabled"
+        aria-haspopup="true"
+        aria-expanded="false"
+        data-toggle="tooltip"
+        data-placement="top"
+        data-html="true"
+        title="Browse registered {{ elementType }}"
+      >
+        <i class="far fa-folder-open mx-2"></i>
+        <span>Browse</span>
+      </div>
     </button>
   </div>
 </div>

--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -35,4 +35,19 @@
       <a class="dropdown-item" href="#">Separated link</a>
     </div> -->
   </div>
+  <button
+    *ngIf="browseButton"
+    class="btn btn-primary"
+    data-toggle="tooltip"
+    data-placement="bottom"
+    data-html="true"
+    title="list all {{ elementType }} or search {{
+      elementType
+    }} by UUID or Name"
+    (click)="onKeyUpEnter()"
+    style="width: 105px"
+  >
+    <i class="fas fa-search mx-2"></i>
+    <span>Search</span>
+  </button>
 </div>

--- a/src/app/components/search-bar/search-bar.component.html
+++ b/src/app/components/search-bar/search-bar.component.html
@@ -50,4 +50,22 @@
     <i class="fas fa-search mx-2"></i>
     <span>Search</span>
   </button>
+
+  <div *ngIf="showAllButtonName" class="mx-2 mr-4" style="width: 135px">
+    <button
+      [hidden]="!actualFilterValue && !searchAll"
+      class="btn btn-primary"
+      type="button"
+      (click)="reset()"
+      aria-haspopup="true"
+      aria-expanded="false"
+      data-toggle="tooltip"
+      data-placement="top"
+      data-html="true"
+      title="Show {{ showAllButtonName }}"
+    >
+      <i class="fas fa-list mx-2"></i>
+      <span>{{ showAllButtonName }}</span>
+    </button>
+  </div>
 </div>

--- a/src/app/components/search-bar/search-bar.component.scss
+++ b/src/app/components/search-bar/search-bar.component.scss
@@ -1,3 +1,19 @@
-.form-control:focus{
-    border-color: #ced4da;
+.form-control:focus {
+  border-color: #ced4da;
+}
+
+.browse-disabled {
+  background-color: var(--eosc-green);
+  color: white;
+}
+
+.browse-enabled {
+  background-color: var(--eosc-green-dark);
+  color: white;
+}
+
+button:disabled,
+button[disabled] {
+  cursor: none;
+  pointer-events: none;
 }

--- a/src/app/components/search-bar/search-bar.component.scss
+++ b/src/app/components/search-bar/search-bar.component.scss
@@ -1,0 +1,3 @@
+.form-control:focus{
+    border-color: #ced4da;
+}

--- a/src/app/components/search-bar/search-bar.component.ts
+++ b/src/app/components/search-bar/search-bar.component.ts
@@ -1,4 +1,12 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { Logger, LoggerManager } from 'src/app/utils/logging';
@@ -12,43 +20,67 @@ export class SearchBarComponent implements OnInit {
   _actualFilterValue: string;
   _sortingOrder: string = 'desc';
   _searchAllValues: boolean = false;
+  browseButtonEnabled: boolean = false;
 
-  @Input() showAllButtonName: string;
-  @Input() browseButton: boolean = true;
+  @Input() goBackButtonName: string;
+  @Input() enableBrowseButton: string;
+  @Input() searchButtonName: string = 'Search';
+  @Input() allowEmptySearch: boolean = false;
   @Input() elementType: string;
   @Input() filterValue: string;
   @Input() sortingOrder: string;
+  @Output() browseEnabled = new EventEmitter<boolean>();
   @Output() filterValueChange = new EventEmitter<string>();
   @Output() sortingOrderChange = new EventEmitter<string>();
   @ViewChild('searchInputText') searchInputText: ElementRef;
+  @ViewChild('searchButton') searchButton: ElementRef;
 
   // initialize logger
   private logger: Logger = LoggerManager.create('SearchBarComponent');
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   ngAfterViewInit() {
     fromEvent(this.searchInputText.nativeElement, 'input')
       .pipe(map((event: Event) => (event.target as HTMLInputElement).value))
       .pipe(debounceTime(800))
       .pipe(distinctUntilChanged())
-      .subscribe(data => {
+      .subscribe((data) => {
         this.emitValue(data);
         this.logger.debug('Current filter value: ', this._actualFilterValue);
       });
   }
 
   public onKeyUpEnter() {
+    if (!this.actualFilterValue && !this.allowEmptySearch) return;
     this._searchAllValues = true;
     this.emitValue(this.actualFilterValue);
   }
 
+  public updateTooltips() {
+    const title: string = !this.actualFilterValue
+      ? 'Browse registered ' + this.elementType
+      : 'Search ' + this.elementType + ' by UUID or name';
+    this.searchButton.nativeElement.setAttribute('data-original-title', title);
+  }
+
+  public onBrowseButtonClick($event) {
+    this.browseButtonEnabled = !this.browseButtonEnabled;
+    this.logger.debug('OnShowAllChange', $event, this.browseButtonEnabled);
+    this.browseEnabled.emit(this.browseButtonEnabled);
+    if (this.browseButtonEnabled) {
+      this._searchAllValues = true;
+      this.emitValue(this.actualFilterValue);
+    } else {
+      this.reset();
+    }
+  }
+
   public set actualFilterValue(value: string) {
     this._actualFilterValue = value;
-    if (value && value.length > 0)
-      this._searchAllValues = false;
+    if (value && value.length > 0) this._searchAllValues = false;
     this.logger.debug('Current filter value: ', this._actualFilterValue);
   }
 
@@ -66,9 +98,12 @@ export class SearchBarComponent implements OnInit {
   }
 
   private emitValue(value: string) {
-    let valueToEmit = (this.actualFilterValue && this.actualFilterValue.length > 0)
-      ? ("SEARCH_KEY###" + this.actualFilterValue) : "______ALL_____";
+    let valueToEmit =
+      this.actualFilterValue && this.actualFilterValue.length > 0
+        ? 'SEARCH_KEY###' + this.actualFilterValue
+        : '______ALL_____';
     this.filterValueChange.emit(valueToEmit);
+    this.updateTooltips();
     this.logger.debug('Current emitted value: ', valueToEmit);
   }
 
@@ -77,11 +112,14 @@ export class SearchBarComponent implements OnInit {
   }
 
   public reset() {
-    if (this._searchAllValues === true
-      || this._actualFilterValue && this._actualFilterValue.length > 0) {
+    if (
+      this._searchAllValues === true ||
+      (this._actualFilterValue && this._actualFilterValue.length > 0)
+    ) {
       this._actualFilterValue = null;
       this._searchAllValues = false;
       this.filterValueChange.emit(null);
     }
+    this.updateTooltips();
   }
 }

--- a/src/app/components/search-bar/search-bar.component.ts
+++ b/src/app/components/search-bar/search-bar.component.ts
@@ -13,6 +13,8 @@ export class SearchBarComponent implements OnInit {
   _sortingOrder: string = 'desc';
   _searchAllValues: boolean = false;
 
+  @Input() showAllButtonName: string;
+  @Input() browseButton: boolean = true;
   @Input() elementType: string;
   @Input() filterValue: string;
   @Input() sortingOrder: string;

--- a/src/app/components/stats-pie-chart/stats-pie-chart.component.ts
+++ b/src/app/components/stats-pie-chart/stats-pie-chart.component.ts
@@ -1,13 +1,17 @@
 import {
-  ChangeDetectorRef, Component,
-  Input, OnChanges, OnInit, SimpleChanges
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
 } from '@angular/core';
 import { ChartDataSets, ChartOptions, ChartType } from 'chart.js';
 import { Label } from 'ng2-charts';
 import {
   AbstractStats,
   AggregatedStatusStats,
-  InstanceStats
+  InstanceStats,
 } from 'src/app/models/stats.model';
 import { Logger, LoggerManager } from 'src/app/utils/logging';
 
@@ -17,11 +21,10 @@ import { Logger, LoggerManager } from 'src/app/utils/logging';
   styleUrls: ['./stats-pie-chart.component.scss'],
 })
 export class StatsPieChartComponent implements OnInit, OnChanges {
-  @Input() stats!: AbstractStats;
+  _stats: AbstractStats = null;
 
   // initialize logger
   private logger: Logger = LoggerManager.create('StatsPieChartComponent');
-
 
   public pieChartOptions: ChartOptions = {
     responsive: true,
@@ -69,13 +72,21 @@ export class StatsPieChartComponent implements OnInit, OnChanges {
   public pieChartLegend = false;
   public pieChartPlugins = [];
 
-  constructor(private cdr: ChangeDetectorRef) { }
+  constructor(private cdr: ChangeDetectorRef) {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
-  ngOnChanges(changes: SimpleChanges): void {
+  @Input()
+  set stats(stats: AbstractStats) {
+    this._stats = stats;
     this.update();
   }
+
+  get stats(): AbstractStats {
+    return this._stats;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {}
 
   ngAfterViewInit() {
     this.logger.debug('after view init ' + this.stats);
@@ -104,15 +115,23 @@ export class StatsPieChartComponent implements OnInit, OnChanges {
     return this.stats instanceof AggregatedStatusStats
       ? ['#1f8787', '#f9b233', '#dc3545', 'grey']
       : this.stats instanceof InstanceStats
-        ? ['#1f8787', '#dc3545', '#ffc107', '#6c757d', '#17a2b8', '#fd7e14', 'grey']
-        : ['#D5D8DC'];
+      ? [
+          '#1f8787',
+          '#dc3545',
+          '#ffc107',
+          '#6c757d',
+          '#17a2b8',
+          '#fd7e14',
+          'grey',
+        ]
+      : ['#D5D8DC'];
   }
 
   public getLabels() {
     return this.stats instanceof AggregatedStatusStats
       ? [['Passing'], ['Some passing'], ['Failing'], ['Unavailable']]
       : this.stats instanceof InstanceStats
-        ? [
+      ? [
           ['Passed'],
           ['Failed'],
           ['Error'],
@@ -121,7 +140,7 @@ export class StatsPieChartComponent implements OnInit, OnChanges {
           ['Waiting'],
           ['Unavailable'],
         ]
-        : [['Unknown']];
+      : [['Unknown']];
   }
 
   public get data(): Array<number> {
@@ -134,7 +153,7 @@ export class StatsPieChartComponent implements OnInit, OnChanges {
     } else {
       data.push(1);
     }
-    this.logger.debug('Data', data);
+    this.logger.debug('Data', data, this.stats);
     return data;
   }
 }

--- a/src/app/components/test-instances/test-instances.component.ts
+++ b/src/app/components/test-instances/test-instances.component.ts
@@ -80,7 +80,7 @@ export class TestInstancesComponent implements OnInit, OnChanges {
       "paging": true,
       "lengthChange": true,
       "lengthMenu": [5, 10, 20, 50, 75, 100],
-      "searching": true,
+      "searching": false,
       "ordering": true,
       "order": [[1, 'asc']],
       "columnDefs": [{

--- a/src/app/components/test-suites/test-suites.component.ts
+++ b/src/app/components/test-suites/test-suites.component.ts
@@ -79,7 +79,7 @@ export class TestSuitesComponent implements OnInit, OnChanges {
       "paging": true,
       "lengthChange": true,
       "lengthMenu": [5, 10, 20, 50, 75, 100],
-      "searching": true,
+      "searching": false,
       "ordering": true,
       "order": [[1, 'asc']],
       "columnDefs": [{

--- a/src/app/components/workflow-version-selector/workflow-version-selector.component.html
+++ b/src/app/components/workflow-version-selector/workflow-version-selector.component.html
@@ -17,7 +17,9 @@
             v.name +
             (v.isLatest
               ? '<span class=\'mx-2 badge badge-success\' style=\'font-size: 0.8em;\'>latest</span>'
-              : '<span style=\'color: white;\'>old</span>')
+              : '<span class=\'max-2\' style=\'display: block; min-width: ' +
+                (workflow.currentVersion.version['version'].length + 7) +
+                'ch;\'> </span>')
           "
         ></option>
       </ng-container>

--- a/src/app/components/workflow-version-selector/workflow-version-selector.component.html
+++ b/src/app/components/workflow-version-selector/workflow-version-selector.component.html
@@ -1,12 +1,26 @@
-<select class="form-select selectpicker show-tick" data-width="fit" data-style="version"
-    aria-label="Select workflow version" (change)="selectVersion($event.target.value)">
+<div *ngIf="workflow">
+  <select
+    #selectPicker
+    class="form-select selectpicker show-tick version-picker"
+    data-width="fit"
+    data-style="version"
+    aria-label="Select workflow version"
+    (change)="selectVersion($event.target.value)"
+  >
     <ng-container *ngIf="versions">
-        <ng-container *ngFor="let v of versions">
-            <option [value]="v.name" [selected]="v.name == workflow.currentVersion.version['version']"
-                class="version-option"
-                [attr.data-content]="v.name + (v.isLatest ? '<span class=\'mx-2 badge badge-success\' style=\'font-size: 0.8em;\'>latest</span>' : '')">
-                {{ v.name }}
-            </option>
-        </ng-container>
+      <ng-container *ngFor="let v of versions">
+        <option
+          [value]="v.name"
+          [selected]="v.name == workflow.currentVersion.version['version']"
+          class="version-option"
+          [attr.data-content]="
+            v.name +
+            (v.isLatest
+              ? '<span class=\'mx-2 badge badge-success\' style=\'font-size: 0.8em;\'>latest</span>'
+              : '<span style=\'color: white;\'>old</span>')
+          "
+        ></option>
+      </ng-container>
     </ng-container>
-</select>
+  </select>
+</div>

--- a/src/app/components/workflow-version-selector/workflow-version-selector.component.scss
+++ b/src/app/components/workflow-version-selector/workflow-version-selector.component.scss
@@ -1,0 +1,8 @@
+.white-badge {
+  color: white !important;
+  background-color: white !important;
+}
+
+.version-option {
+  color: white !important;
+}

--- a/src/app/components/workflow-version-selector/workflow-version-selector.component.ts
+++ b/src/app/components/workflow-version-selector/workflow-version-selector.component.ts
@@ -1,56 +1,76 @@
 import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
-  Input, OnInit,
-  Output
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
 } from '@angular/core';
 import {
   Workflow,
   WorkflowVersion,
-  WorkflowVersionDescriptor
+  WorkflowVersionDescriptor,
 } from 'src/app/models/workflow.model';
 import { Logger, LoggerManager } from 'src/app/utils/logging';
 import { AppService } from 'src/app/utils/services/app.service';
 
+declare var $: any;
 @Component({
   selector: 'workflow-version-selector',
   templateUrl: './workflow-version-selector.component.html',
   styleUrls: ['./workflow-version-selector.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class WorkflowVersionSelectorComponent implements OnInit {
+export class WorkflowVersionSelectorComponent implements OnInit, OnChanges {
   private _workflow: Workflow;
   private _versions_map: { [name: string]: WorkflowVersionDescriptor };
+
   private _workflow_version: WorkflowVersionDescriptor;
+
+  versions: WorkflowVersionDescriptor[];
 
   @Output() workflow_version = new EventEmitter<WorkflowVersion>();
   @Output() loadingWorkflowVersion = new EventEmitter<Workflow>();
+
+  @ViewChild('searchInputText') selectPicker: ElementRef;
 
   // initialize logger
   private logger: Logger = LoggerManager.create(
     'WorkflowVersionSelectorComponent'
   );
 
-  constructor(private appService: AppService) { }
+  constructor(
+    private appService: AppService,
+    private cdRef: ChangeDetectorRef
+  ) {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.logger.debug('Change detected');
+    $('.selectpicker').selectpicker();
+  }
 
   @Input()
   set workflow(w: Workflow) {
     this.logger.debug('Setting workflow version: ', w);
     this._workflow = w;
     this._versions_map = {};
+    this.versions = w.versionDescriptors;
     w.versionDescriptors.forEach(
       (v: WorkflowVersionDescriptor, index) => (this._versions_map[v.name] = v)
     );
     this.logger.debug('Version map:', this._versions_map);
+    this.cdRef.detectChanges();
   }
 
   get workflow(): Workflow {
     return this._workflow;
-  }
-
-  get versions(): WorkflowVersionDescriptor[] {
-    return this._workflow ? this._workflow.versionDescriptors : null;
   }
 
   public selectVersion(version: string) {

--- a/src/app/models/stats.model.ts
+++ b/src/app/models/stats.model.ts
@@ -9,10 +9,10 @@ export const AggregatedTestStatus = [
 ];
 
 export const AggregatedTestStatusMap = {
-  'all_failing': ['failing', 'all_failing', 'allfailing'],
-  'all_passing': ['passing', 'all_passing', 'allpassing'],
-  'some_passing': ['some_passing', 'somepassing'],
-  'unknown': ['unavailable', 'unknown']
+  all_failing: ['failing', 'all_failing', 'allfailing'],
+  all_passing: ['passing', 'all_passing', 'allpassing'],
+  some_passing: ['some_passing', 'somepassing'],
+  unknown: ['unavailable', 'unknown'],
 };
 
 export const TestStatus = [

--- a/src/app/utils/services/api.service.ts
+++ b/src/app/utils/services/api.service.ts
@@ -7,7 +7,7 @@ import { Registry, RegistryWorkflow } from 'src/app/models/registry.models';
 import {
   AggregatedStatusStats,
   InstanceStats,
-  Status
+  Status,
 } from 'src/app/models/stats.model';
 import { Suite } from 'src/app/models/suite.models';
 import { TestBuild } from 'src/app/models/testBuild.models';
@@ -62,28 +62,33 @@ export class ApiService {
 
   get_current_user_notifications(): Observable<Array<UserNotification>> {
     return this.http
-      .get(this.apiBaseUrl + '/users/current/notifications', this.get_http_options())
+      .get(
+        this.apiBaseUrl + '/users/current/notifications',
+        this.get_http_options()
+      )
       .pipe(
         retry(3),
         map((data) => {
           let result = [];
           for (let d of data['items']) {
-            result.push(new UserNotification(d))
+            result.push(new UserNotification(d));
           }
           return result;
         })
       );
   }
 
-  setNotificationsReadingTime(notifications: UserNotification[]): Observable<UserNotification[]> {
+  setNotificationsReadingTime(
+    notifications: UserNotification[]
+  ): Observable<UserNotification[]> {
     let readTime = Date.now();
     let body = {
-      'items': notifications.map(function (n) {
+      items: notifications.map(function (n) {
         return {
           uuid: n['uuid'],
-          read: String(readTime)
-        }
-      })
+          read: String(readTime),
+        };
+      }),
     };
     return this.http
       .put(
@@ -123,7 +128,9 @@ export class ApiService {
   }
 
   deleteNotifications(notifications: UserNotification[]): Observable<object> {
-    let body = notifications.map(function (n) { return n['uuid']; });
+    let body = notifications.map(function (n) {
+      return n['uuid'];
+    });
     return this.http
       .patch(
         this.apiBaseUrl + '/users/current/notifications',
@@ -174,10 +181,17 @@ export class ApiService {
       );
   }
 
-  getRegistryWorkflow(registry_uuid: string, workflow_identifier: string): Observable<RegistryWorkflow> {
+  getRegistryWorkflow(
+    registry_uuid: string,
+    workflow_identifier: string
+  ): Observable<RegistryWorkflow> {
     return this.http
       .get(
-        this.apiBaseUrl + '/registries/' + registry_uuid + '/index/' + workflow_identifier,
+        this.apiBaseUrl +
+          '/registries/' +
+          registry_uuid +
+          '/index/' +
+          workflow_identifier,
         this.get_http_options()
       )
       .pipe(
@@ -191,7 +205,7 @@ export class ApiService {
 
   updateWorkflowName(workflow: WorkflowVersion): Observable<any> {
     let body = {
-      name: workflow.name
+      name: workflow.name,
     };
     return this.http
       .put(
@@ -205,7 +219,7 @@ export class ApiService {
           workflow.public = !workflow.public;
           this.logger.debug('Changed workflow name to:' + workflow.name);
         }),
-        tap((data) => this.logger.debug('Workflow name changed to: ', data)),
+        tap((data) => this.logger.debug('Workflow name changed to: ', data))
       );
   }
 
@@ -223,9 +237,13 @@ export class ApiService {
         retry(3),
         map((data) => {
           workflow.public = !workflow.public;
-          this.logger.debug('Changed workflow visibility: public=' + workflow.public);
+          this.logger.debug(
+            'Changed workflow visibility: public=' + workflow.public
+          );
         }),
-        tap((data) => this.logger.debug('Workflow visibility changed to: ', data)),
+        tap((data) =>
+          this.logger.debug('Workflow visibility changed to: ', data)
+        )
       );
   }
 
@@ -233,17 +251,21 @@ export class ApiService {
     workflow: RegistryWorkflow,
     version: string = null,
     name: string = null,
-    is_public: boolean = false): Observable<object> {
+    is_public: boolean = false
+  ): Observable<object> {
     let data = {
-      "identifier": workflow.identifier,
-      "name": name,
-      "version": version,
-      "public": is_public,
-      "uuid": uuidv4()
-    }
+      identifier: workflow.identifier,
+      name: name,
+      version: version,
+      public: is_public,
+      uuid: uuidv4(),
+    };
     return this.http
       .post(
-        this.apiBaseUrl + '/registries/' + workflow.registry.uuid + '/workflows',
+        this.apiBaseUrl +
+          '/registries/' +
+          workflow.registry.uuid +
+          '/workflows',
         data,
         this.get_http_options()
       )
@@ -292,8 +314,10 @@ export class ApiService {
       );
   }
 
-  deleteWorkflowVersion(uuid: string, version: string):
-    Observable<{ uuid: string; version: string }> {
+  deleteWorkflowVersion(
+    uuid: string,
+    version: string
+  ): Observable<{ uuid: string; version: string }> {
     return this.http
       .delete(
         this.apiBaseUrl + '/workflows/' + uuid + '/versions/' + version,
@@ -308,13 +332,9 @@ export class ApiService {
       );
   }
 
-  deleteWorkflow(uuid: string):
-    Observable<{ uuid: string; }> {
+  deleteWorkflow(uuid: string): Observable<{ uuid: string }> {
     return this.http
-      .delete(
-        this.apiBaseUrl + '/workflows/' + uuid,
-        this.get_http_options()
-      )
+      .delete(this.apiBaseUrl + '/workflows/' + uuid, this.get_http_options())
       .pipe(
         retry(3),
         map(() => {
@@ -324,12 +344,11 @@ export class ApiService {
       );
   }
 
-
   downloadROCrate(workflow: WorkflowVersion): Observable<any> {
     let token = JSON.parse(localStorage.getItem('token'));
     let headers = new HttpHeaders();
     if (token) {
-      headers.append["Authorization"] = 'Bearer ' + token['token']['value'];
+      headers.append['Authorization'] = 'Bearer ' + token['token']['value'];
     }
     return this.http
       .get(workflow.downloadLink, {
@@ -359,7 +378,9 @@ export class ApiService {
           }
           return workflow;
         }),
-        tap((data) => this.logger.debug('Workflow visibility changed to: ', data))
+        tap((data) =>
+          this.logger.debug('Workflow visibility changed to: ', data)
+        )
       );
   }
 
@@ -382,7 +403,9 @@ export class ApiService {
           }
           return workflow;
         }),
-        tap((data) => this.logger.debug('Workflow visibility changed to: ', data))
+        tap((data) =>
+          this.logger.debug('Workflow visibility changed to: ', data)
+        )
       );
   }
 
@@ -400,7 +423,7 @@ export class ApiService {
     let url: string = !filteredByUser
       ? this.apiBaseUrl + `/workflows?status=${status}&versions=${versions}`
       : this.apiBaseUrl +
-      `/users/current/workflows?status=${status}&versions=${versions}&subscriptions=${includeSubScriptions}`;
+        `/users/current/workflows?status=${status}&versions=${versions}&subscriptions=${includeSubScriptions}`;
     return this.http.get(url, this.get_http_options()).pipe(
       retry(3),
       tap((data) => this.logger.debug('Loaded workflows: ', data)),
@@ -427,7 +450,7 @@ export class ApiService {
     return forkJoin(queries).pipe(
       map((result) => {
         let workflow: Workflow = new Workflow(result[0]);
-        workflow.updateDescriptors(result[1]["versions"]);
+        workflow.updateDescriptors(result[1]['versions']);
         this.logger.debug('Loaded workflow', workflow);
         return workflow;
       }),
@@ -463,7 +486,7 @@ export class ApiService {
 
     let queries: Array<object> = [workflow];
 
-    if (load_status) {
+    if (options.load_status) {
       const status = this.http
         .get<Status>(
           this.apiBaseUrl + '/workflows/' + uuid + '/status?version=' + version,
@@ -481,7 +504,7 @@ export class ApiService {
 
     let w = new WorkflowVersion({ uuid: uuid });
     let suites = null;
-    if (load_suites) {
+    if (options.load_suites) {
       suites = this.get_suites(w, version);
       if (suites) queries.push(suites);
     }
@@ -489,36 +512,21 @@ export class ApiService {
     return forkJoin(queries).pipe(
       map((result) => {
         w.update(result[0]);
-        if (load_status)
-          w.status = result[1];
-        w.suites = new AggregatedStatusStats(load_status && load_suites ? result[2] : (load_suites ? result[1] : []));
-        this.logger.debug('workflow', w);
+        if (options.load_status) w.status = result[1];
+        this.logger.debug('The complete workflow version SUITEs', result[2]);
+        w.suites = new AggregatedStatusStats(
+          options.load_status && options.load_suites
+            ? result[2]
+            : options.load_suites
+            ? result[1]
+            : []
+        );
+        this.logger.debug('The complete workflow version', w);
         return w;
       }),
       tap((result) => this.logger.debug('Loaded workflow: ', result)),
       retry(3)
     );
-  }
-
-  get_suites_parallel(uuid: string): Observable<Suite[]> {
-    this.logger.debug('Loading suites....');
-    return this.http
-      .get<Suite[]>(
-        this.apiBaseUrl + '/workflows/' + uuid + '/suites',
-        this.get_http_options()
-      )
-      .pipe(
-        retry(3),
-        map((rawSuitesData) => {
-          let suites: Suite[] = [];
-          for (let suiteData of rawSuitesData['items']) {
-            this.loadSuite(suiteData).subscribe((suite: Suite) => {
-              suites.push(suite);
-            });
-          }
-          return suites;
-        })
-      );
   }
 
   loadSuite(suiteData: Object): Observable<Suite> {
@@ -543,9 +551,9 @@ export class ApiService {
               this.http
                 .get(
                   this.apiBaseUrl +
-                  '/instances/' +
-                  instanceData['uuid'] +
-                  '/latest-builds',
+                    '/instances/' +
+                    instanceData['uuid'] +
+                    '/latest-builds',
                   this.get_http_options()
                 )
                 .pipe(
@@ -568,7 +576,10 @@ export class ApiService {
                     return instance;
                   }),
                   tap((result) => {
-                    this.logger.debug('Loaded latest test instance builds', result);
+                    this.logger.debug(
+                      'Loaded latest test instance builds',
+                      result
+                    );
                   })
                 )
             );
@@ -588,7 +599,10 @@ export class ApiService {
       );
   }
 
-  get_suites(workflow: WorkflowVersion, version: string = "latest"): Observable<Suite[]> {
+  get_suites(
+    workflow: WorkflowVersion,
+    version: string = 'latest'
+  ): Observable<Suite[]> {
     this.logger.debug('Loading suites of workflow ....', workflow);
     return this.http
       .get<Suite[]>(
@@ -598,7 +612,12 @@ export class ApiService {
       .pipe(
         retry(3),
         map((rawSuitesData) => {
-          return rawSuitesData['items'];
+          return rawSuitesData['items'].map((data: any) => {
+            const suite = { ...data };
+            if ('aggregate_test_status' in suite)
+              suite['status'] = suite['aggregate_test_status'];
+            return suite;
+          });
         }),
         mergeMap((rawSuitesData: []) => {
           this.logger.debug('Suites', rawSuitesData);
@@ -606,16 +625,15 @@ export class ApiService {
           let dataIndexMap: { [key: string]: number } = {};
           let queries = [];
           for (let suite of rawSuitesData) {
-
             let instances: Array<any> = suite['instances'];
             for (let instanceData of instances) {
               dataIndexMap[instanceData['uuid']] = queries.length;
               queries.push(
                 this.http.get(
                   this.apiBaseUrl +
-                  '/instances/' +
-                  instanceData['uuid'] +
-                  '/latest-builds',
+                    '/instances/' +
+                    instanceData['uuid'] +
+                    '/latest-builds',
                   this.get_http_options()
                 )
               );
@@ -709,7 +727,7 @@ export class ApiService {
 
   updateSuite(suite: Suite): Observable<any> {
     let body = {
-      name: suite.name
+      name: suite.name,
     };
     return this.http
       .put(
@@ -728,7 +746,7 @@ export class ApiService {
 
   updateTestInstance(instance: TestInstance): Observable<any> {
     let body = {
-      name: instance.name
+      name: instance.name,
     };
     return this.http
       .put(
@@ -744,7 +762,6 @@ export class ApiService {
         tap((data) => this.logger.debug('TestInstance name changed to: ', data))
       );
   }
-
 
   getLatestTestInstance(uuid: string): Observable<any> {
     return this.http
@@ -784,11 +801,11 @@ export class ApiService {
     return this.http
       .get(
         this.apiBaseUrl +
-        '/instances/' +
-        testInstanceUUID +
-        '/builds/' +
-        buildID +
-        '/logs',
+          '/instances/' +
+          testInstanceUUID +
+          '/builds/' +
+          buildID +
+          '/logs',
         this.get_http_options()
       )
       .pipe(
@@ -797,12 +814,18 @@ export class ApiService {
           return data;
         }),
         tap((result) => {
-          this.logger.debug('Loaded logs of test instance build', buildID, result);
+          this.logger.debug(
+            'Loaded logs of test instance build',
+            buildID,
+            result
+          );
         })
       );
   }
 
-  public checkROCrateAvailability(workflow: WorkflowVersion): Observable<boolean> {
+  public checkROCrateAvailability(
+    workflow: WorkflowVersion
+  ): Observable<boolean> {
     return this.http
       .head(workflow.downloadLink, this.get_http_options({}, true))
       .pipe(

--- a/src/app/utils/services/api.service.ts
+++ b/src/app/utils/services/api.service.ts
@@ -438,19 +438,26 @@ export class ApiService {
 
   get_workflow_version(
     uuid: string,
-    version: string = "latest",
-    previous_versions = false,
-    ro_crate = false,
-    load_suites = true,
-    load_status = true
+    version: string = 'latest',
+    options: {
+      previous_versions: boolean;
+      ro_crate: boolean;
+      load_suites: boolean;
+      load_status: boolean;
+    } = {
+      previous_versions: false,
+      ro_crate: false,
+      load_suites: true,
+      load_status: true,
+    }
   ): Observable<WorkflowVersion> {
     this.logger.debug('Request login');
     const workflow = this.http.get<WorkflowVersion>(
       this.apiBaseUrl + '/workflows/' + uuid + '/versions/' + version,
       this.get_http_options({
         // TODO: remove previoius versions
-        previous_versions: previous_versions,
-        ro_crate: ro_crate,
+        previous_versions: options.previous_versions,
+        ro_crate: options.ro_crate,
       })
     );
 

--- a/src/app/utils/services/api.service.ts
+++ b/src/app/utils/services/api.service.ts
@@ -33,11 +33,10 @@ export class ApiService {
     this.logger.debug('API Service created');
   }
 
-  private get_http_options(params = {}, skip: boolean = false) {
+  private get_http_options(params = {}) {
     let token = JSON.parse(localStorage.getItem('token'));
     let http_headers = {
-      // 'Content-Type':  'application/json',
-      skip: String(skip),
+      'Content-Type': 'text/plain',
     };
     if (token) {
       http_headers['Authorization'] = 'Bearer ' + token['token']['value'];
@@ -827,7 +826,7 @@ export class ApiService {
     workflow: WorkflowVersion
   ): Observable<boolean> {
     return this.http
-      .head(workflow.downloadLink, this.get_http_options({}, true))
+      .head(workflow.downloadLink, this.get_http_options({}))
       .pipe(
         map((result) => {
           this.logger.debug('Result: ', result);

--- a/src/app/utils/services/app.service.ts
+++ b/src/app/utils/services/app.service.ts
@@ -480,8 +480,10 @@ export class AppService {
           return stats;
         }),
         finalize(() => {
-          if (this._workflows && this._workflows.length == 0)
+          if (this._workflows && this._workflows.length == 0) {
             this.setLoadingWorkflows(false);
+            this.subjectWorkflows.next(this._workflows);
+          }
         })
       );
   }

--- a/src/app/utils/services/app.service.ts
+++ b/src/app/utils/services/app.service.ts
@@ -481,15 +481,22 @@ export class AppService {
     version: string = 'latest',
     status: boolean = false
   ): Observable<WorkflowVersion> {
-    return this.api.get_workflow_version(w.uuid, version, true, true, true, status).pipe(
-      map((workflow_version: WorkflowVersion) => {
-        this.logger.debug('Loaded data:', workflow_version);
-        //w.update(wdata);
-        //w.suites = wdata.suites;
-        this.logger.debug('Workflow data updated!');
-        return workflow_version;
+    return this.api
+      .get_workflow_version(w.uuid, version, {
+        previous_versions: true,
+        ro_crate: true,
+        load_status: status,
+        load_suites: true,
       })
-    );
+      .pipe(
+        map((workflow_version: WorkflowVersion) => {
+          this.logger.debug('Loaded workflow version data:', workflow_version);
+          //w.update(wdata);
+          //w.suites = wdata.suites;
+          this.logger.debug('Workflow data updated!');
+          return workflow_version;
+        })
+      );
   }
 
   public selectWorkflowVersion(uuid: string, version: string = 'latest') {
@@ -508,16 +515,23 @@ export class AppService {
       this._selectWorkflowVersion(this._workflow);
     } else if (!this._workflow_versions) {
       this.api
-        .get_workflow_version(uuid, version, true, true, true, true)
-        .subscribe((w: WorkflowVersion) => {
-          this._selectWorkflowVersion(w);
-        },
+        .get_workflow_version(uuid, version, {
+          previous_versions: true,
+          ro_crate: true,
+          load_status: true,
+          load_suites: true,
+        })
+        .subscribe(
+          (w: WorkflowVersion) => {
+            this._selectWorkflowVersion(w);
+          },
           (error) => {
-            this.logger.error("Error", error);
+            this.logger.error('Error', error);
             if (error.status === 404) {
               this.selectWorkflowVersion(uuid, 'latest');
             }
-          });
+          }
+        );
     } else {
       w = this._workflow_versions.find(
         (w: WorkflowVersion) =>
@@ -525,7 +539,12 @@ export class AppService {
       );
       if (!w || !w.suites) {
         this.api
-          .get_workflow_version(uuid, version, true, true, true, true)
+          .get_workflow_version(uuid, version, {
+            previous_versions: true,
+            ro_crate: true,
+            load_status: true,
+            load_suites: true,
+          })
           .subscribe((w: WorkflowVersion) => {
             this._selectWorkflowVersion(w);
           });
@@ -559,9 +578,17 @@ export class AppService {
         map((data) => {
           this.logger.debug('Data of registered workflow', data);
           this.api
-            .get_workflow_version(data['uuid'], version, false, true)
+            .get_workflow_version(data['uuid'], version, {
+              previous_versions: false,
+              ro_crate: true,
+              load_status: true,
+              load_suites: true,
+            })
             .subscribe((workflow_version: WorkflowVersion) => {
-              this.logger.debug('Registered Workflow RO-Crate:', workflow_version);
+              this.logger.debug(
+                'Registered Workflow RO-Crate:',
+                workflow_version
+              );
               this._workflow_versions.push(workflow_version);
               this.logger.debug('Workflow data loaded!');
               let workflow: Workflow = this.findWorkflow(uuid);
@@ -609,7 +636,12 @@ export class AppService {
         map((data) => {
           this.logger.debug('Data of registered workflow', data);
           this.api
-            .get_workflow_version(data['uuid'], version, false, true)
+            .get_workflow_version(data['uuid'], version, {
+              previous_versions: false,
+              ro_crate: true,
+              load_status: true,
+              load_suites: true,
+            })
             .subscribe((workflow_version: WorkflowVersion) => {
               this.logger.debug('Registered Workflow RO-Crate:', workflow_version);
               this._workflow_versions.push(workflow_version);

--- a/src/app/utils/services/app.service.ts
+++ b/src/app/utils/services/app.service.ts
@@ -1,9 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import {
-  forkJoin, Observable, Subject,
-  Subscription
-} from 'rxjs';
+import { forkJoin, Observable, Subject, Subscription } from 'rxjs';
 import { catchError, finalize, map, tap } from 'rxjs/operators';
 import { UserNotification } from 'src/app/models/notification.model';
 import { Registry, RegistryWorkflow } from 'src/app/models/registry.models';
@@ -15,7 +12,7 @@ import { User } from 'src/app/models/user.modes';
 import {
   Workflow,
   WorkflowVersion,
-  WorkflowVersionDescriptor
+  WorkflowVersionDescriptor,
 } from 'src/app/models/workflow.model';
 import { AuthService } from 'src/app/utils/services/auth.service';
 import { Logger, LoggerManager } from '../logging';

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -62,7 +62,7 @@
             <ng-container *ngIf="workflowNameFilter == '______ALL_____'; then allWorkflows; else matchingWorkflows;">
             </ng-container>
             <ng-template #allWorkflows>
-              {{ browseButtonEnabled ? 'Registered Workflows' : isUserLogged() ? "Dashboard" : "Workflows" }}              
+              {{ browseButtonEnabled && isUserLogged() ? 'Registered Workflows' :  isUserLogged() ? "Dashboard" : "Workflows" }}              
             </ng-template>
             <ng-template #matchingWorkflows>Workflows matching "<b>{{workflowNameFilter}}</b>"</ng-template>
           </ng-template>

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -302,18 +302,21 @@
                         <span>{{ w.version.submitter.username }}</span>
                       </div>
                       <div *ngIf="w.version && w.authors && w.authors.length > 0"
-                        class="text-xs cut-text font-weight-light">
+                        class="text-xs font-weight-light">
                         <span class="icon-wrapper">
                           <i class="fas fa-xs fa-solid fa-users mr-1"></i>
                         </span>
                         <b>author<span *ngIf="w.authors.length > 1">s</span>: </b>
-                        <div class="d-inline" *ngFor="let author of w.authors; index as a_index;">
-                          <!-- <div *ngIf="author.url" class="d-inline">
-                            <a href="{{author.url}}">{{ author.name }}</a><span class="m-0 p-0"
-                              *ngIf="a_index < w.authors.length - 1">, </span>
+                        <div class="d-inline" style="display: flex; flex-wrap: wrap;">
+                          <div class="d-inline" *ngFor="let author of w.authors; index as a_index;">
+                            
+                            <div *ngIf="author.name && author.url" class="d-inline">
+                              <a href="{{author.url}}" [innerHTML]="author.name">{{ author.name }}</a><span class="m-0 p-0"
+                                *ngIf="a_index < w.authors.length - 1">, </span>
+                            </div>
+                            <div *ngIf="author.name && !author.url" class="d-inline">{{ author.name }}<span class="m-0 p-0"
+                                *ngIf="a_index < w.authors.length - 1">, </span></div>
                           </div>
-                          <div *ngIf="!author.url" class="d-inline">{{ author.name }}<span class="m-0 p-0"
-                              *ngIf="a_index < w.authors.length - 1">, </span></div> -->
                         </div>
                       </div>
                       <div *ngIf="isUserLogged()">

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -1,4 +1,4 @@
-<app-loader [enabled]="(isLoading|async)!==false"></app-loader>
+<app-loader [enabled]="(isLoading|async)!==false" [marginTop]="500"></app-loader>
 
 <app-workflow-uploader></app-workflow-uploader>
 
@@ -30,15 +30,22 @@
     <!-- *ngIf="workflows && (isLoading|async)===false -->
     <ng-container>
       <h2 class="text-primary font-weight-light p-2">
-        <span *ngIf="!isUserLogged()">Workflows</span>
-        <span *ngIf="isUserLogged() && !searchModeEnabled" data-toggle="tooltip" data-placement="right" data-html="true"
-          title="The dashboard collects your subscribed workflows">
-          Dashboard
-        </span>
-        <div *ngIf="isUserLogged() && searchModeEnabled">
-          <ng-container *ngIf="(isLoading|async)!==false; then searchingForWorkflows; else searchResults;">
+        <div>
+          <span *ngIf="((isLoading|async)!==false) && !workflowNameFilter" data-toggle="tooltip" data-placement="right" data-html="true"
+            title="The dashboard collects your subscribed workflows">
+            {{ "Loading " + (isUserLogged() ? "Dashboard" : "Workflows") + "....."}}
+          </span>
+          <span *ngIf="(isLoading|async)===false && (!workflowNameFilter || workflowNameFilter.length==0)" data-toggle="tooltip" data-placement="right" data-html="true"
+            title="The dashboard collects your subscribed workflows">
+            {{ isUserLogged() ? "Dashboard" : "Workflows" }}
+          </span>
+        </div>
+        <div *ngIf="workflowNameFilter && workflowNameFilter.length>0">
+          <ng-container *ngIf="(isLoading|async)===true; then searchingForWorkflows; else searchResults;">
           </ng-container>
-          <ng-template #searchingForWorkflows>Searching...</ng-template>
+          <ng-template #searchingForWorkflows>
+            {{workflowNameFilter !== '______ALL_____' ? "Searching....." : "Loading....."}}
+          </ng-template>
           <ng-template #searchResults>
             <ng-container
               *ngIf="((workflows | itemFilterPipe: workflowNameFilter).length == 0); then noWorkflow; else foundWorkflows">
@@ -54,7 +61,9 @@
           <ng-template #foundWorkflows>
             <ng-container *ngIf="workflowNameFilter == '______ALL_____'; then allWorkflows; else matchingWorkflows;">
             </ng-container>
-            <ng-template #allWorkflows>Workflows found</ng-template>
+            <ng-template #allWorkflows>
+              {{ browseButtonEnabled ? 'Registered Workflows' : isUserLogged() ? "Dashboard" : "Workflows" }}              
+            </ng-template>
             <ng-template #matchingWorkflows>Workflows matching "<b>{{workflowNameFilter}}</b>"</ng-template>
           </ng-template>
         </div>
@@ -69,7 +78,7 @@
               data-placement="bottom" data-html="true"
               title="<span class='text-xs'><i class='fas fa-question-circle mx-1'></i> click to filter <b>passing</b> workflows</span>">
               <!-- Loading (remove the following to stop the loading)-->
-              <div *ngIf="(isLoading|async)!==false" class="overlay dark">
+              <div *ngIf="(isLoading|async)===true" class="overlay dark">
                 <i class="fas fa-3x fa-sync-alt"></i>
               </div>
               <div *ngIf="!(isLoading|async) && workflows && statusFilter && statusFilter != 'all_passing'"
@@ -95,7 +104,7 @@
               data-placement="bottom" data-html="true"
               title="<span class='text-xs'><i class='fas fa-question-circle mx-1'></i> click to filter workflows partially <b>passing</b></span>">
               <!-- Loading (remove the following to stop the loading)-->
-              <div *ngIf="(isLoading|async)!==false" class="overlay dark">
+              <div *ngIf="(isLoading|async)===true" class="overlay dark">
                 <i class="fas fa-3x fa-sync-alt"></i>
               </div>
               <div *ngIf="!(isLoading|async) && workflows && statusFilter && statusFilter != 'some_passing'"
@@ -120,7 +129,7 @@
               data-placement="bottom" data-html="true"
               title="<span class='text-xs'><i class='fas fa-question-circle mx-1'></i> click to filter <b>failing</b> workflows</span>">
               <!-- Loading (remove the following to stop the loading)-->
-              <div *ngIf="(isLoading|async)!==false" class="overlay dark">
+              <div *ngIf="(isLoading|async)===true" class="overlay dark">
                 <i class="fas fa-3x fa-sync-alt"></i>
               </div>
               <div *ngIf="!(isLoading|async) && workflows && statusFilter && statusFilter != 'all_failing'"
@@ -146,7 +155,7 @@
               data-toggle="tooltip" data-placement="bottom"
               title="<span class='text-xs'><i class='fas fa-question-circle mx-1'></i> click to filter workflows in <b>unknown</b> state</span>">
               <!-- Loading (remove the following to stop the loading)-->
-              <div *ngIf="(isLoading|async)!==false" class="overlay dark">
+              <div *ngIf="(isLoading|async)===true" class="overlay dark">
                 <i class="fas fa-3x fa-sync-alt"></i>
               </div>
               <div *ngIf="!(isLoading|async) && workflows && statusFilter && statusFilter != 'unknown'"
@@ -176,8 +185,9 @@
     <div class="container-fluid">
       <!-- Search Bar -->
       <item-search-bar elementType="workflows" [(filterValue)]="workflowNameFilter"
-        [(sortingOrder)]="workflowSortingOrder" 
-        [browseButton]="true" showAllButtonName="{{isUserLogged() ? 'Dashboard': ''}}"></item-search-bar>
+        [(sortingOrder)]="workflowSortingOrder" [allowEmptySearch]="false" [searchButtonName]="'Search'"
+        (browseEnabled)="setBrowseButtonEnabled($event)" [enableBrowseButton]="isUserLogged()"
+        [goBackButtonName]="'Dashboard'"></item-search-bar>
 
       <div>
         <div class="card card-primary card-outline" [hidden]="!workflows && (isLoading|async)!==false">
@@ -298,12 +308,12 @@
                         </span>
                         <b>author<span *ngIf="w.authors.length > 1">s</span>: </b>
                         <div class="d-inline" *ngFor="let author of w.authors; index as a_index;">
-                          <div *ngIf="author.url" class="d-inline">
+                          <!-- <div *ngIf="author.url" class="d-inline">
                             <a href="{{author.url}}">{{ author.name }}</a><span class="m-0 p-0"
                               *ngIf="a_index < w.authors.length - 1">, </span>
                           </div>
                           <div *ngIf="!author.url" class="d-inline">{{ author.name }}<span class="m-0 p-0"
-                              *ngIf="a_index < w.authors.length - 1">, </span></div>
+                              *ngIf="a_index < w.authors.length - 1">, </span></div> -->
                         </div>
                       </div>
                       <div *ngIf="isUserLogged()">
@@ -359,7 +369,7 @@
                         <div class="text-muted mt-1" style="font-size: 8pt;">{{ w.type }}</div>
                       </div>
                     </td>
-                    <td class="text-center align-middle font-weight-light" style="min-width: 120px">
+                    <td class="text-center align-middle font-weight-light" style="min-width: auto;">
                       <workflow-version-selector [workflow]="w.workflow"
                         (loadingWorkflowVersion)="loadingWorkflowVersion($event)"
                         (workflow_version)="updateSelectedVersion($event)">

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -176,7 +176,8 @@
     <div class="container-fluid">
       <!-- Search Bar -->
       <item-search-bar elementType="workflows" [(filterValue)]="workflowNameFilter"
-        [(sortingOrder)]="workflowSortingOrder"></item-search-bar>
+        [(sortingOrder)]="workflowSortingOrder" 
+        [browseButton]="true" showAllButtonName="Dashboard"></item-search-bar>
 
       <div>
         <div class="card card-primary card-outline" [hidden]="!workflows && (isLoading|async)!==false">

--- a/src/app/views/dashboard/dashboard.component.html
+++ b/src/app/views/dashboard/dashboard.component.html
@@ -177,7 +177,7 @@
       <!-- Search Bar -->
       <item-search-bar elementType="workflows" [(filterValue)]="workflowNameFilter"
         [(sortingOrder)]="workflowSortingOrder" 
-        [browseButton]="true" showAllButtonName="Dashboard"></item-search-bar>
+        [browseButton]="true" showAllButtonName="{{isUserLogged() ? 'Dashboard': ''}}"></item-search-bar>
 
       <div>
         <div class="card card-primary card-outline" [hidden]="!workflows && (isLoading|async)!==false">

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -1,16 +1,27 @@
 import { Location } from '@angular/common';
-import { ChangeDetectorRef, Component, HostListener, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  HostListener,
+  NgZone,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { DataTableDirective } from 'angular-datatables';
 import { ToastrService } from 'ngx-toastr';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { MouseClickHandler } from 'src/app/models/common.models';
 import {
   AggregatedStatusStats,
   AggregatedStatusStatsItem,
-  AggregatedTestStatusMap
+  AggregatedTestStatusMap,
 } from 'src/app/models/stats.model';
 import { TestBuild } from 'src/app/models/testBuild.models';
-import { Workflow, WorkflowVersion, WorkflowVersionDescriptor } from 'src/app/models/workflow.model';
+import { Workflow, WorkflowVersion } from 'src/app/models/workflow.model';
 import { Logger, LoggerManager } from 'src/app/utils/logging';
 import { AppService } from 'src/app/utils/services/app.service';
 import { InputDialogService } from 'src/app/utils/services/input-dialog.service';
@@ -24,7 +35,7 @@ declare var $: any;
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
   private _workflows: Workflow[] = null;
   // reference to workflows stats
   private _workflowStats: AggregatedStatusStats | null;
@@ -43,8 +54,13 @@ export class DashboardComponent implements OnInit {
   public editModeEnabled: boolean = false;
   private _searchModeEnabled: boolean = false;
   private openUploader: boolean = false;
+  _browseButtonEnabled: boolean = false;
 
   private statsFilter = new StatsFilterPipe();
+
+  dtTrigger: Subject<any> = new Subject();
+  @ViewChild(DataTableDirective, { static: false })
+  dtElement: DataTableDirective;
 
   // Reference to the dataTable instance
   private workflowDataTable: any = null;
@@ -66,46 +82,48 @@ export class DashboardComponent implements OnInit {
     private router: Router,
     private route: ActivatedRoute,
     private inputDialog: InputDialogService,
-    private uploaderService: WorkflowUploaderService
-  ) { }
+    private uploaderService: WorkflowUploaderService,
+    private ngZone: NgZone
+  ) {}
 
   ngOnInit() {
     this.logger.debug('Dashboard Created!!');
-    this.userLoggedSubscription = this.appService.observableUserLogged
-      .subscribe((isUserLogged) => {
+    this.userLoggedSubscription = this.appService.observableUserLogged.subscribe(
+      (isUserLogged) => {
         this.updatingDataTable = true;
         this._workflowStats.clear();
-        this.filteredWorkflows = [];
-        this.cdref.detectChanges();
-        this.workflowDataTable.clear();
-        this.workflowDataTable.draw();
-      });
+        this.appService.loadWorkflows(false, false, false).subscribe((data) => {
+          this.logger.debug('Loaded workflows ', data);
+        });
+      }
+    );
     this.workflowsStatsSubscription = this.appService.observableWorkflows.subscribe(
       (workflows: Workflow[]) => {
-        this.logger.debug("Loaded workflows: ", workflows);
+        this.logger.debug('X Loaded workflows: ', workflows);
         this.prepareTableData(workflows);
         this.refreshDataTable();
       }
     );
 
-    this.queryParamsSubscription = this.route.queryParams
-      .subscribe(params => {
-        console.debug("Query params: ", params);
+    this.queryParamsSubscription = this.route.queryParams.subscribe(
+      (params) => {
+        console.debug('Query params: ', params);
         if ('status' in params) {
           // Parse and normalize status filter
           let status: string = params['status'].toLowerCase();
-          console.debug("Status: ", status);
+          console.debug('Status: ', status);
           for (let s in AggregatedTestStatusMap) {
             if (s === status || AggregatedTestStatusMap[s].includes(status)) {
               this.statusFilter = s;
             }
           }
         }
-      });
+      }
+    );
 
     this.internalParamSubscription = this.route.params.subscribe((params) => {
       this.logger.debug('Dashboard params:', params);
-      if (params['add'] == "true") {
+      if (params['add'] == 'true') {
         this.openUploader = true;
         this.location.replaceState('/dashboard');
       }
@@ -119,27 +137,34 @@ export class DashboardComponent implements OnInit {
       this.refreshDataTable();
       this.appService.setLoadingWorkflows(false);
     } else {
-      this.appService.loadWorkflows(
-        true,
-        this.isUserLogged(),
-        this.isUserLogged()
-      ).subscribe(
-        (data) => {
-          this.logger.debug("Loaded workflows ", data);
-          if (this.openUploader === true)
-            this.openWorkflowUploader();
-        }
-      );
+      this.appService
+        .loadWorkflows(true, this.isUserLogged(), this.isUserLogged())
+        .subscribe((data) => {
+          this.logger.debug('Loaded workflows ', data);
+          if (this.openUploader === true) this.openWorkflowUploader();
+        });
     }
   }
 
-  ngAfterViewChecked() {
+  ngAfterViewChecked() {}
+
+  ngAfterViewInit(): void {
+    $('[data-toggle="tooltip"]', function () {
+      $(this).tooltip('hide');
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // this.rerender();
+    $('[data-toggle="tooltip"]', function () {
+      $(this).tooltip('hide');
+    });
   }
 
   private prepareTableData(workflows: Workflow[] = null) {
     workflows = workflows || this._workflows;
     if (!workflows) return;
-    this.logger.debug("Loaded workflows: ", workflows);
+    this.logger.debug('Loaded workflows: ', workflows);
     // Initialize workflow stats
     let stats = new AggregatedStatusStats();
     //let workflow_versions: WorkflowVersion[] = data
@@ -158,43 +183,59 @@ export class DashboardComponent implements OnInit {
       this.filterByStatus(this.statusFilter, false);
     } else {
       this.filteredWorkflows =
-        this.searchModeEnabled || !this.isUserLogged()
+        // this.searchModeEnabled || !this.isUserLogged()
+        this.browseButtonEnabled || !this.isUserLogged()
           ? this._workflowStats.all
           : this._workflowStats.all.filter(
-            (v) => v.subscriptions && v.subscriptions.length > 0);
+              (v) => v.subscriptions && v.subscriptions.length > 0
+            );
     }
 
     this.refreshDataTable();
   }
 
-
   public get workflowNameFilter(): string {
     return this._workflowNameFilter;
   }
 
-  public set workflowNameFilter(value: string) {
-    this._workflowNameFilter = value ? value.replace("SEARCH_KEY###", "") : "";
-    this.editModeEnabled = false;
-    this._searchModeEnabled = true; //(this._workflowNameFilter && this._workflowNameFilter !== '______ALL_____') ? true : false;
+  public get browseButtonEnabled(): boolean {
+    return this._browseButtonEnabled;
+  }
+
+  public set browseButtonEnabled(value: boolean) {
+    this.setBrowseButtonEnabled(value);
+  }
+
+  public setBrowseButtonEnabled(value: boolean) {
+    this._browseButtonEnabled = value;
+    if (!this._browseButtonEnabled) this.workflowNameFilter = '';
+    this.update();
+  }
+
+  public update() {
+    this._searchModeEnabled = this._browseButtonEnabled;
+    this.logger.debug('Browse button enabled');
     this.updatingDataTable = true;
+
     this._workflowStats.clear();
+    this.workflowDataTable.clear();
     this.filteredWorkflows = [];
-    this.cdref.detectChanges();
-    this.logger.debug("Updating workflow name filter", this.workflowNameFilter);
-    if (value && value.length > 0) {
-      this.workflowDataTable.clear();
-      this.appService.loadWorkflows(
-        false, false, this.isUserLogged()
-      ).subscribe();
+    this._workflows = [];
+
+    if (this.browseButtonEnabled) {
+      this.appService
+        .loadWorkflows(false, false, this.isUserLogged())
+        .subscribe((data) => {});
     } else {
-      if (!value) this._searchModeEnabled = false;
-      this.workflowDataTable.clear();
-      this.appService.loadWorkflows(
-        false,
-        this.isUserLogged(),
-        this.isUserLogged()
-      ).subscribe();
+      this.appService
+        .loadWorkflows(false, this.isUserLogged(), this.isUserLogged())
+        .subscribe((data) => {});
     }
+  }
+
+  public set workflowNameFilter(value: string) {
+    this._workflowNameFilter = value ? value.replace('SEARCH_KEY###', '') : '';
+    this.editModeEnabled = false;
   }
 
   public get isLoading(): Observable<boolean> {
@@ -207,18 +248,19 @@ export class DashboardComponent implements OnInit {
 
   public openWorkflowUploader() {
     this.uploaderService.show({
-      title: "Register Workflow",
+      title: 'Register Workflow',
       iconClass: 'fas fa-cogs',
       iconClassSize: 'fa-7x',
-      iconImage: null
+      iconImage: null,
     });
   }
 
   public openWorkflowVersionUploader(workflow: Workflow) {
     this.uploaderService.show({
       iconImage: '/assets/icons/branch-add-eosc-green.png',
-      title: "Register new version of <br><b>\"" + workflow.name + "\"</b>",
-      workflowUUID: workflow.uuid, workflowName: workflow.name
+      title: 'Register new version of <br><b>"' + workflow.name + '"</b>',
+      workflowUUID: workflow.uuid,
+      workflowName: workflow.name,
     });
   }
 
@@ -237,15 +279,13 @@ export class DashboardComponent implements OnInit {
   }
 
   public updateSelectedVersion(workflow_version: WorkflowVersion) {
-    this.logger.debug("Updated workflow version", workflow_version);
+    this.logger.debug('Updated workflow version', workflow_version);
     this.prepareTableData();
   }
-
 
   public isLoadingWorkflowVersion(workflow: Workflow) {
     return workflow && this.loadingWorkflowVersions.indexOf(workflow.uuid) >= 0;
   }
-
 
   public loadingWorkflowVersion(workflow: Workflow) {
     if (workflow) {
@@ -259,17 +299,22 @@ export class DashboardComponent implements OnInit {
   }
 
   public deleteWorkflowVersion(w: WorkflowVersion) {
-    this.logger.debug("Deleting workflow version....", w);
+    this.logger.debug('Deleting workflow version....', w);
     this.inputDialog.show({
       iconImage: '/assets/icons/branch-delete-eosc-green.png',
-      iconImageSize: "160",
+      iconImageSize: '160',
       description:
-        'Delete version <b>"' + w.version["version"] + '"</b><br/> of workflow <b>' + w.name + '</b>?',
+        'Delete version <b>"' +
+        w.version['version'] +
+        '"</b><br/> of workflow <b>' +
+        w.name +
+        '</b>?',
       onConfirm: () => {
         this.updatingDataTable = true;
-        this.appService.deleteWorkflowVersion(w)
+        this.appService
+          .deleteWorkflowVersion(w)
           .subscribe((wd: { uuid: string; version: string }) => {
-            this.logger.debug("Workflow deleted", wd);
+            this.logger.debug('Workflow deleted', wd);
             this.refreshDataTable(false);
           });
       },
@@ -277,16 +322,16 @@ export class DashboardComponent implements OnInit {
   }
 
   public deleteWorkflow(w: Workflow) {
-    this.logger.debug("Deleting workflow ....", w);
+    this.logger.debug('Deleting workflow ....', w);
     this.inputDialog.show({
       iconClass: 'fas fa-trash-alt',
-      description:
-        'Delete workflow <b>' + w.name + '</b>?',
+      description: 'Delete workflow <b>' + w.name + '</b>?',
       onConfirm: () => {
         this.updatingDataTable = true;
-        this.appService.deleteWorkflow(w)
+        this.appService
+          .deleteWorkflow(w)
           .subscribe((wd: { uuid: string; version: string }) => {
-            this.logger.debug("Workflow deleted", wd);
+            this.logger.debug('Workflow deleted', wd);
             this.refreshDataTable(false);
           });
       },
@@ -307,10 +352,9 @@ export class DashboardComponent implements OnInit {
       this.filteredWorkflows = this.searchModeEnabled
         ? this._workflowStats.all
         : this._workflowStats.all.filter(
-          (v) => v.subscriptions && v.subscriptions.length > 0
-        );
-      if (!this.searchModeEnabled)
-        this.refreshDataTable();
+            (v) => v.subscriptions && v.subscriptions.length > 0
+          );
+      if (!this.searchModeEnabled) this.refreshDataTable();
     });
   }
 
@@ -330,7 +374,9 @@ export class DashboardComponent implements OnInit {
   public showWorkflowDetails(w: WorkflowVersion) {
     this.clickHandler.click(() => {
       this.router.navigate([
-        '/workflow', { uuid: w.asUrlParam(), version: w.version["version"] }]);
+        '/workflow',
+        { uuid: w.asUrlParam(), version: w.version['version'] },
+      ]);
     });
   }
 
@@ -345,13 +391,16 @@ export class DashboardComponent implements OnInit {
   }
 
   public updateWorkflowName(w: WorkflowVersion) {
-    this.logger.debug("Updating workflow name", w);
-    this.appService.updateWorkflowName(w).subscribe(() => {
-      this.toastService.success("Workflow updated!", '', { timeOut: 2500 });
-      w['editingMode'] = false;
-    },
+    this.logger.debug('Updating workflow name', w);
+    this.appService.updateWorkflowName(w).subscribe(
+      () => {
+        this.toastService.success('Workflow updated!', '', { timeOut: 2500 });
+        w['editingMode'] = false;
+      },
       (error) => {
-        this.toastService.error("Unable to update workflow", '', { timeOut: 2500 });
+        this.toastService.error('Unable to update workflow', '', {
+          timeOut: 2500,
+        });
         this.logger.error(error);
       }
     );
@@ -366,17 +415,24 @@ export class DashboardComponent implements OnInit {
         'Change visibility to <b>' +
         (!w.public ? 'public' : 'private') +
         '</b>?',
-      confirmText: "Confirm",
+      confirmText: 'Confirm',
       onConfirm: () => {
-        this.appService.changeWorkflowVisibility(w).subscribe(() => {
-          $('.workflow-visibility-' + w.uuid)
-            .tooltip('hide')
-            .attr('data-original-title', this.getWorkflowVisibilityTitle(w))
-            .tooltip('show');
-          this.toastService.success("Workflow visibility updated!", '', { timeOut: 2500 });
-        },
+        this.appService.changeWorkflowVisibility(w).subscribe(
+          () => {
+            $('.workflow-visibility-' + w.uuid)
+              .tooltip('hide')
+              .attr('data-original-title', this.getWorkflowVisibilityTitle(w))
+              .tooltip('show');
+            this.toastService.success('Workflow visibility updated!', '', {
+              timeOut: 2500,
+            });
+          },
           (error) => {
-            this.toastService.error("Unable to change workflow visibility", '', { timeOut: 2500 });
+            this.toastService.error(
+              'Unable to change workflow visibility',
+              '',
+              { timeOut: 2500 }
+            );
             this.logger.error(error);
           }
         );
@@ -395,8 +451,10 @@ export class DashboardComponent implements OnInit {
 
   public getStatsLength(workflows: AggregatedStatusStatsItem[]): number {
     let items = workflows;
-    if (this.isUserLogged())
-      items = workflows.filter((v) => v.subscriptions && v.subscriptions.length > 0);
+    if (this.isUserLogged() && !this.browseButtonEnabled)
+      items = workflows.filter(
+        (v) => v.subscriptions && v.subscriptions.length > 0
+      );
     return items.length;
   }
 
@@ -409,9 +467,8 @@ export class DashboardComponent implements OnInit {
     this.filteredWorkflows = workflows;
   }
 
-
   public selectWorkflowVersion(version: any) {
-    this.logger.debug("Selected workflow version:", version);
+    this.logger.debug('Selected workflow version:', version);
   }
 
   public filterByStatus(status: string, asToggle: boolean = true) {
@@ -421,16 +478,22 @@ export class DashboardComponent implements OnInit {
       status = status == 'any' ? 'all' : status;
       if (status != this.statusFilter || !asToggle) {
         this.filteredWorkflows =
-          (!this.isUserLogged() || this.searchModeEnabled) ? this._workflowStats[status]
+          !this.isUserLogged() || this.searchModeEnabled
+            ? this._workflowStats[status]
             : this._workflowStats[status].filter(
-              (v: { subscriptions: string | any[]; }) => v.subscriptions && v.subscriptions.length > 0);
+                (v: { subscriptions: string | any[] }) =>
+                  v.subscriptions && v.subscriptions.length > 0
+              );
         this.statusFilter = status;
         this.refreshDataTable();
       } else {
         this.filteredWorkflows =
-          (!this.isUserLogged() || this.searchModeEnabled) ? this._workflowStats['all']
+          !this.isUserLogged() || this.searchModeEnabled
+            ? this._workflowStats['all']
             : this._workflowStats['all'].filter(
-              (v: { subscriptions: string | any[]; }) => v.subscriptions && v.subscriptions.length > 0);
+                (v: { subscriptions: string | any[] }) =>
+                  v.subscriptions && v.subscriptions.length > 0
+              );
         this.statusFilter = null;
         // remove status params from query if defined
         const queryParams = { ...this.route.snapshot.queryParams };
@@ -444,8 +507,7 @@ export class DashboardComponent implements OnInit {
   }
 
   private refreshDataTable(resetTableStatus: boolean = true) {
-    if (resetTableStatus)
-      this.updatingDataTable = true;
+    if (resetTableStatus) this.updatingDataTable = true;
     try {
       this.destroyDataTable();
       this.cdref.detectChanges();
@@ -454,8 +516,7 @@ export class DashboardComponent implements OnInit {
       $('.selectpicker').selectpicker();
       // $('#registryWorkflowSelector').selectpicker('refresh');
     } finally {
-      if (resetTableStatus)
-        this.updatingDataTable = false;
+      if (resetTableStatus) this.updatingDataTable = false;
     }
   }
 
@@ -466,71 +527,86 @@ export class DashboardComponent implements OnInit {
 
   private initDataTable() {
     if (this.workflowDataTable) return;
-    this.workflowDataTable = $("#workflowsDashboard").DataTable({
-      "paging": true,
-      "lengthChange": true,
-      "lengthMenu": [5, 10, 20, 50, 75, 100],
-      "searching": true,
-      "ordering": true,
-      "order": [[1, 'asc']],
-      "columnDefs": [{
-        "targets": [0, 5, 6, 7],
-        "orderable": false
-      }],
-      "info": true,
-      "autoWidth": false,
-      "responsive": true,
-      // "deferRender": true,
-      // "scrollY": "520",
-      "stateSave": true,
-      "language": {
-        search: "",
-        searchPlaceholder: "Filter your dashboard",
-        "decimal": "",
-        "emptyTable":
-          // this.updatingDataTable ? "" :
-          this.workflowNameFilter && this.workflowNameFilter.length > 0
-            ? "No matching workflows"
-            : "<h4 class='mt-3'>No workflow found</h4>."
-            + (this.isUserLogged() ? "<div class=\"m-2\"> Click on "
-              + "<a class='add-wf' href=\"/dashboard;add=true\"><i class=\"fas fa-plus-circle\"></i> "
-              + "to add a new workflow</a> "
-              + "<br>or use the main search box <br>to find and subscribe to existing workflows</div>" : ""),
-        "info": "Showing _START_ to _END_ of _TOTAL_ workflows",
-        "infoEmpty": "Showing 0 to 0 of 0 workflows",
-        "infoFiltered": "(filtered from a total of _MAX_"
-          + (this.isUserLogged() ? " subscribed" : "") + " workflows)",
-        "infoPostFix": "",
-        "thousands": ",",
-        "lengthMenu": "Show _MENU_ workflows",
-        "loadingRecords": "Loading workflows...",
-        "processing": "Processing workflows...",
-        "zeroRecords": "No matching "
-          + (this.isUserLogged() ? "subscribed" : "") + " workflow found",
-        "paginate": {
-          "first": "First",
-          "last": "Last",
-          "next": "Next",
-          "previous": "Previous"
+    this.ngZone.runOutsideAngular(() => {
+      this.workflowDataTable = $('#workflowsDashboard').DataTable({
+        paging: true,
+        lengthChange: true,
+        lengthMenu: [5, 10, 20, 50, 75, 100],
+        searching: true,
+        ordering: true,
+        order: [[1, 'asc']],
+        columnDefs: [
+          {
+            targets: [0, 5, 6, 7],
+            orderable: false,
+          },
+        ],
+        info: true,
+        autoWidth: false,
+        responsive: true,
+        // "deferRender": true,
+        // "scrollY": "520",
+        stateSave: true,
+        language: {
+          search: '',
+          searchPlaceholder: 'Filter your dashboard',
+          decimal: '',
+          emptyTable:
+            // this.updatingDataTable ? "" :
+            this.workflowNameFilter && this.workflowNameFilter.length > 0
+              ? this.updatingDataTable
+                ? 'Loading workflows...'
+                : 'No matching workflows'
+              : this.updatingDataTable
+              ? 'Loading workflows...'
+              : "<h4 class='mt-3'>No workflow found</h4>." +
+                (this.isUserLogged()
+                  ? '<div class="m-2"> Click on ' +
+                    '<a class=\'add-wf\' href="/dashboard;add=true"><i class="fas fa-plus-circle"></i> ' +
+                    'to add a new workflow</a> ' +
+                    '<br>or use the main search box <br>to find and subscribe to existing workflows</div>'
+                  : ''),
+          info: 'Showing _START_ to _END_ of _TOTAL_ workflows',
+          infoEmpty: 'Showing 0 to 0 of 0 workflows',
+          infoFiltered:
+            '(filtered from a total of _MAX_' +
+            (this.isUserLogged() ? ' subscribed' : '') +
+            ' workflows)',
+          infoPostFix: '',
+          thousands: ',',
+          lengthMenu: 'Show _MENU_ workflows',
+          loadingRecords: 'Loading workflows...',
+          processing: 'Processing workflows...',
+          zeroRecords:
+            'No matching ' +
+            (this.isUserLogged() ? 'subscribed' : '') +
+            ' workflow found',
+          paginate: {
+            first: 'First',
+            last: 'Last',
+            next: 'Next',
+            previous: 'Previous',
+          },
         },
-        "aria": {
-          "sortAscending": ": activate to sort column ascending",
-          "sortDescending": ": activate to sort column descending"
-        }
-      }
+      });
+      // Add tooltip to the SearchBox
+      $('input[type=search]')
+        .attr('data-placement', 'top')
+        .attr('data-toggle', 'tooltip')
+        .attr('data-html', 'true')
+        .attr('title', 'Filter by UUID or Name');
     });
-    // Add tooltip to the SearchBox
-    $("input[type=search]")
-      .attr('data-placement', 'top')
-      .attr('data-toggle', "tooltip")
-      .attr('data-html', "true")
-      .attr('title', "Filter by UUID or Name");
   }
 
   private destroyDataTable() {
     if (this.workflowDataTable) {
-      this.workflowDataTable.destroy();
-      this.workflowDataTable = null;
+      this.ngZone.runOutsideAngular(() => {
+        this.workflowDataTable.destroy();
+        this.workflowDataTable = null;
+        $('[data-toggle="tooltip"]', function () {
+          $(this).tooltip('hide');
+        });
+      });
     }
   }
 
@@ -542,8 +618,10 @@ export class DashboardComponent implements OnInit {
       this.internalParamsSubscription.unsubscribe();
     if (this.queryParamsSubscription)
       this.queryParamsSubscription.unsubscribe();
-    if (this.userLoggedSubscription)
-      this.userLoggedSubscription.unsubscribe();
+    if (this.userLoggedSubscription) this.userLoggedSubscription.unsubscribe();
     this.logger.debug('Destroying dashboard component');
+
+    // Do not forget to unsubscribe the event
+    if (this.dtTrigger) this.dtTrigger.unsubscribe();
   }
 }

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -513,7 +513,6 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
       this.cdref.detectChanges();
       this.initDataTable();
       this.cdref.detectChanges();
-      $('.selectpicker').selectpicker();
       // $('#registryWorkflowSelector').selectpicker('refresh');
     } finally {
       if (resetTableStatus) this.updatingDataTable = false;

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -613,8 +613,5 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
       this.queryParamsSubscription.unsubscribe();
     if (this.userLoggedSubscription) this.userLoggedSubscription.unsubscribe();
     this.logger.debug('Destroying dashboard component');
-
-    // Do not forget to unsubscribe the event
-    if (this.dtTrigger) this.dtTrigger.unsubscribe();
   }
 }

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -231,6 +231,7 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
   public set workflowNameFilter(value: string) {
     this._workflowNameFilter = value ? value.replace('SEARCH_KEY###', '') : '';
     this.editModeEnabled = false;
+    this.refreshDataTable();
   }
 
   public get isLoading(): Observable<boolean> {
@@ -546,7 +547,7 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
           searchPlaceholder: 'Filter your dashboard',
           decimal: '',
           emptyTable:
-            this.updatingDataTable === true
+            this.appService.isLoadingWorkflows() === true
               ? 'Loading workflows...'
               : this.workflowNameFilter && this.workflowNameFilter.length > 0
               ? 'No matching workflows'

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -7,18 +7,16 @@ import {
   NgZone,
   OnChanges,
   OnInit,
-  SimpleChanges,
-  ViewChild,
+  SimpleChanges
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { DataTableDirective } from 'angular-datatables';
 import { ToastrService } from 'ngx-toastr';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { MouseClickHandler } from 'src/app/models/common.models';
 import {
   AggregatedStatusStats,
   AggregatedStatusStatsItem,
-  AggregatedTestStatusMap,
+  AggregatedTestStatusMap
 } from 'src/app/models/stats.model';
 import { TestBuild } from 'src/app/models/testBuild.models';
 import { Workflow, WorkflowVersion } from 'src/app/models/workflow.model';
@@ -57,10 +55,6 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
   _browseButtonEnabled: boolean = false;
 
   private statsFilter = new StatsFilterPipe();
-
-  dtTrigger: Subject<any> = new Subject();
-  @ViewChild(DataTableDirective, { static: false })
-  dtElement: DataTableDirective;
 
   // Reference to the dataTable instance
   private workflowDataTable: any = null;

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -552,19 +552,17 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
           searchPlaceholder: 'Filter your dashboard',
           decimal: '',
           emptyTable:
-            // this.updatingDataTable ? "" :
-            this.workflowNameFilter && this.workflowNameFilter.length > 0
-              ? this.updatingDataTable
-                ? 'Loading workflows...'
-                : 'No matching workflows'
-              : this.updatingDataTable
+            this.updatingDataTable === true
               ? 'Loading workflows...'
+              : this.workflowNameFilter && this.workflowNameFilter.length > 0
+              ? 'No matching workflows'
               : "<h4 class='mt-3'>No workflow found</h4>." +
                 (this.isUserLogged()
                   ? '<div class="m-2"> Click on ' +
                     '<a class=\'add-wf\' href="/dashboard;add=true"><i class="fas fa-plus-circle"></i> ' +
-                    'to add a new workflow</a> ' +
-                    '<br>or use the main search box <br>to find and subscribe to existing workflows</div>'
+                    'to register a workflow</a>' +
+                    '<br>or use the main search box to find and subscribe ' +
+                    '<br>to workflows registered by others in the community</div>'
                   : ''),
           info: 'Showing _START_ to _END_ of _TOTAL_ workflows',
           infoEmpty: 'Showing 0 to 0 of 0 workflows',

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -7,7 +7,7 @@ import {
   NgZone,
   OnChanges,
   OnInit,
-  SimpleChanges
+  SimpleChanges,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
@@ -16,7 +16,7 @@ import { MouseClickHandler } from 'src/app/models/common.models';
 import {
   AggregatedStatusStats,
   AggregatedStatusStatsItem,
-  AggregatedTestStatusMap
+  AggregatedTestStatusMap,
 } from 'src/app/models/stats.model';
 import { TestBuild } from 'src/app/models/testBuild.models';
 import { Workflow, WorkflowVersion } from 'src/app/models/workflow.model';
@@ -527,7 +527,7 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
         paging: true,
         lengthChange: true,
         lengthMenu: [5, 10, 20, 50, 75, 100],
-        searching: true,
+        searching: false,
         ordering: true,
         order: [[1, 'asc']],
         columnDefs: [

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -99,9 +99,10 @@ export class DashboardComponent implements OnInit, OnChanges, AfterViewInit {
     );
     this.workflowsStatsSubscription = this.appService.observableWorkflows.subscribe(
       (workflows: Workflow[]) => {
-        this.logger.debug('X Loaded workflows: ', workflows);
+        this.logger.debug('Loaded workflows: ', workflows);
+        this.updatingDataTable = false;
         this.prepareTableData(workflows);
-        this.refreshDataTable();
+        this.refreshDataTable(false);
       }
     );
 


### PR DESCRIPTION
* update design of search bar. It adds a **Search** button which becomes automatically active when the search input text is not empty. The **X** control allows to clean up the search box
<img width="1412" alt="Screenshot 2023-01-17 at 18 49 38" src="https://user-images.githubusercontent.com/1832243/212974102-f229292a-73f4-495d-a1ac-7afe45a0e2c3.png">

* address issue https://github.com/crs4/life_monitor/issues/285. 
  * A new **Browse** button allows authenticated users to go through the list of registered workflows, subscribe and add them to their dashboard 
![Deshboard](https://user-images.githubusercontent.com/1832243/213252080-06778d81-da1e-4e4f-b51b-925485ee15bd.png)
  * Users can go back the their Dashboard by clicking the **Dashboard** button, visible after clicking on the Browse button <img width="1412" alt="Screenshot 2023-01-17 at 18 28 50" src="https://user-images.githubusercontent.com/1832243/212975659-ebdb1824-9f2f-4e2c-a57a-0b45044d86a4.png">

* fix issue https://github.com/crs4/lifemonitor-web/issues/53: a transient *Loading workflows...* message will be displayed during the loading of registered workflows
![Loading](https://user-images.githubusercontent.com/1832243/212977206-4c0a23b5-33c6-4470-8603-17d23ea5f74e.png)

* fix issue https://github.com/crs4/lifemonitor-web/issues/52
<img width="1232" alt="Screenshot 2023-01-17 at 19 09 02" src="https://user-images.githubusercontent.com/1832243/212977935-55e47271-80db-48eb-8c3f-5cf1c5fc8e8f.png">

* fix issue https://github.com/crs4/life_monitor/issues/281
<img width="1354" alt="Screenshot 2023-01-17 at 17 48 40" src="https://user-images.githubusercontent.com/1832243/212978088-9bbbe783-42aa-4946-8d86-d4a1ee25307f.png">


